### PR TITLE
Ensure eletrum port and protocol is configurable in constants files

### DIFF
--- a/src/pages/Setup.vue
+++ b/src/pages/Setup.vue
@@ -187,7 +187,7 @@ import DepositStep from '../components/setup/DepositStep.vue'
 import ChooseRelayStep from '../components/setup/ChooseRelayStep.vue'
 import ProfileStep from '../components/setup/ProfileStep.vue'
 import SettingsStep from '../components/Settings.vue'
-import { defaultRelayData, defaultRelayUrl, electrumURL } from '../utils/constants'
+import { defaultRelayData, defaultRelayUrl, electrumURL, electrumPort, electrumProtocol } from '../utils/constants'
 import {
   keyserverDisconnectedNotify,
   insuffientFundsNotify,
@@ -538,7 +538,7 @@ export default {
     this.resetChats()
 
     // Set electrum client
-    this.newElectrumClient({ host: electrumURL, port: 50001, protocol: 'tcp' })
+    this.newElectrumClient({ host: electrumURL, port: electrumPort, protocol: electrumProtocol })
     await this.electrumConnect()
     this.electrumKeepAlive()
   }

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -2,7 +2,9 @@ export const minSplitter = 20
 export const maxSplitter = 75
 
 // Electrum constants
-export const electrumURL = 'testnet.imaginary.cash'
+export const electrumURL = 'testnet.bitcoincash.network'
+export const electrumPort = 60002
+export const electrumProtocol = 'tls'
 export const electrumPingInterval = 10_000
 
 // Wallet constants


### PR DESCRIPTION
Our previous electrum server switched to TLS and changed port. This
commit changed the default server, as well as changed some of the values
to be in the constants files.