### PR TITLE
Ensure stamps privkeys are generated using the new digest protocol

### DIFF
--- a/src/store/modules/chats.js
+++ b/src/store/modules/chats.js
@@ -576,30 +576,34 @@ export default {
       // Add UTXO
       let stampOutpoints = message.getStampOutpointsList()
       let outpoints = []
-      for (let i in stampOutpoints) {
-        let stampOutpoint = stampOutpoints[i]
-        let stampTxRaw = Buffer.from(stampOutpoint.getStampTx())
-        let stampTx = cashlib.Transaction(stampTxRaw)
-        let txId = stampTx.hash
-        let vouts = stampOutpoint.getVoutsList()
-        outpoints.push({
-          stampTx,
-          vouts
-        })
-        for (let j in vouts) {
-          let outputIndex = vouts[j]
-          let output = stampTx.outputs[outputIndex]
-          let satoshis = output.satoshis
-          let address = output.script.toAddress('testnet').toLegacyAddress() // TODO: Make generic
-          let stampOutput = {
-            address,
-            outputIndex,
-            satoshis,
-            txId,
-            type: 'stamp',
-            payloadDigest
+
+      if (!outbound) {
+        for (let i in stampOutpoints) {
+          let stampOutpoint = stampOutpoints[i]
+          let stampTxRaw = Buffer.from(stampOutpoint.getStampTx())
+          let stampTx = cashlib.Transaction(stampTxRaw)
+          let txId = stampTx.hash
+          let vouts = stampOutpoint.getVoutsList()
+          outpoints.push({
+            stampTx,
+            vouts
+          })
+          for (let j in vouts) {
+            let outputIndex = vouts[j]
+            let output = stampTx.outputs[outputIndex]
+            let satoshis = output.satoshis
+            let address = output.script.toAddress('testnet').toLegacyAddress() // TODO: Make generic
+            let stampOutput = {
+              address,
+              outputIndex,
+              stampIndex: i,
+              satoshis,
+              txId,
+              type: 'stamp',
+              payloadDigest
+            }
+            dispatch('wallet/addUTXO', stampOutput, { root: true })
           }
-          dispatch('wallet/addUTXO', stampOutput, { root: true })
         }
       }
 


### PR DESCRIPTION
Previously, we used a simple digest of the payload to generate the
stamp private key. However, we changed this since we now allow
stamps to have split outputs. This commit updates the sending
portion of the client to properly calculate stamp privkeys when
spending them.