### PR TITLE
Use new crypto scheme for stealth transaction keys

### DIFF
--- a/src/relay/constructors.js
+++ b/src/relay/constructors.js
@@ -29,7 +29,18 @@ export const constructStealthTransaction = async function (ephemeralPrivKey, des
   // Add ephemeral output
   // NOTE: We're only doing 1 stealth txn, and 1 output for now.
   // But the spec should allow doing confidential amounts.
-  const stealthAddress = constructStealthPubKey(ephemeralPrivKey, destPubKey).toAddress('testnet')
+  const transactionNumber = 0// This should be the index of the transaction in the outpoint list
+  const outputNumber = 0 // This should the index in the outpoint list *NOT* the vout.  Otherwise they can't be reordered before signing
+  const stealthHDPubKey = constructStealthPubKey(ephemeralPrivKey, destPubKey)
+  const stealthPubKey = stealthHDPubKey
+    .deriveChild(44)
+    .deriveChild(145)
+    .deriveChild(transactionNumber)
+    .deriveChild(outputNumber)
+    .publicKey
+
+  const stealthAddress = cashlib.PublicKey(cashlib.crypto.Point.pointToCompressed(stealthPubKey.point))
+
   const stealthOutput = new cashlib.Transaction.Output({
     script: cashlib.Script(new cashlib.Address(stealthAddress)),
     satoshis: amount

--- a/src/relay/crypto.js
+++ b/src/relay/crypto.js
@@ -11,7 +11,14 @@ export const constructStealthPubKey = function (emphemeralPrivKey, destPubKey) {
   let digestPublicKey = PrivateKey.fromBuffer(digest).toPublicKey() // H(ebG)G
 
   let stealthPublicKey = PublicKey(digestPublicKey.point.add(destPubKey.point)) // H(ebG)G + bG
-  return stealthPublicKey
+  return new cashlib.HDPublicKey({
+    publicKey: stealthPublicKey.toBuffer(),
+    depth: 0,
+    network: 'testnet',
+    childIndex: 0,
+    chainCode: digest.slice(0, 32),
+    parentFingerPrint: 0
+  })
 }
 
 export const constructStealthPrivKey = function (emphemeralPubKey, privKey) {
@@ -22,7 +29,15 @@ export const constructStealthPrivKey = function (emphemeralPubKey, privKey) {
   let digestBn = cashlib.crypto.BN.fromBuffer(digest)
 
   let stealthPrivBn = digestBn.add(privKey.bn).mod(cashlib.crypto.Point.getN()) // H(ebG) + b
-  return PrivateKey(stealthPrivBn)
+  const stealthPrivateKey = PrivateKey(stealthPrivBn)
+  return new cashlib.HDPrivateKey({
+    privateKey: stealthPrivateKey.toBuffer(),
+    depth: 0,
+    network: 'testnet',
+    childIndex: 0,
+    chainCode: digest.slice(0, 32),
+    parentFingerPrint: 0
+  })
 }
 
 export const constructStampPubKey = function (outpointDigest, destPubKey) {


### PR DESCRIPTION
In an effort to obfuscate transaction amounts, we have added bundling
to the stealth entries. This allows transfered amounts to be split
over multiple bitcoin cash transactions.

This commit adds support for the new protobuf specification that allows
that. It supports on the receiving end arbitrary splits, but on the
sending end only does one output and one transaction currently.