### PR TITLE
Deouple message handling logic from wallet

### DIFF
--- a/src/store/modules/wallet.js
+++ b/src/store/modules/wallet.js
@@ -1,8 +1,6 @@
 import Vue from 'vue'
-import { constructStampPrivKey, constructStealthPrivKey } from '../../relay/crypto'
-import { PublicKey } from 'bitcore-lib-cash'
+
 import { numAddresses, numChangeAddresses } from '../../utils/constants'
-import { constructOutpointDigest } from '../../relay/constructors'
 
 import formatting from '../../utils/formatting'
 import { calcId } from '../../utils/wallet'
@@ -327,22 +325,12 @@ export default {
         let addr = utxo.address
         utxo['script'] = cashlib.Script.buildPublicKeyHashOut(addr).toHex()
         // Grab private key
-        let signingKey
         if (utxo.type === 'p2pkh') {
-          signingKey = addresses[addr].privKey
-        } else if (utxo.type === 'stamp') {
-          let privKey = getters['getIdentityPrivKey']
-          let outpointDigest = constructOutpointDigest(utxo.stampIndex, utxo.outputIndex, utxo.payloadDigest)
-          signingKey = constructStampPrivKey(outpointDigest, privKey)
-        } else if (utxo.type === 'stealth') {
-          let privKey = getters['getIdentityPrivKey']
-          let ephemeralPubKey = PublicKey(utxo.ephemeralPubKey)
-          signingKey = constructStealthPrivKey(ephemeralPubKey, privKey)
+          signingKeys.push(addresses[addr].privKey)
         } else {
-          // TODO: Handle
+          signingKeys.push(utxo.privKey)
         }
         transaction = transaction.from(utxo)
-        signingKeys.push(signingKey)
 
         // Ensure there are enough fees to cover at least one change output
         let totalFees = (transaction._estimateSize() + 34) * feePerByte


### PR DESCRIPTION
This commit moves the UTXO private key generation to were messages
are received and decoded, rather than placing them in the wallet. This
allows better decoupling of concerns and makes it so you don't
need to add logic to two places every time we add a new message type.