### PR TITLE
Update stealth txn processing for new proto specs

### DIFF
--- a/src/store/modules/chats.js
+++ b/src/store/modules/chats.js
@@ -524,6 +524,7 @@ export default {
       const destinationRaw = payload.getDestination()
       const destPubKey = cashlib.PublicKey.fromBuffer(destinationRaw)
       const destinationAddr = destPubKey.toAddress('testnet').toCashAddress()
+      const identityPrivKey = rootGetters['wallet/getIdentityPrivKey']
 
       // Check whether pre-existing
       if (outbound) {
@@ -560,8 +561,6 @@ export default {
           dispatch('contacts/refresh', senderAddr, { root: true })
         }
       }
-
-      let identityPrivKey = rootGetters['wallet/getIdentityPrivKey']
 
       let scheme = payload.getScheme()
       let entriesRaw
@@ -663,37 +662,41 @@ export default {
           let entryData = entry.getEntryData()
           let stealthMessage = stealth.StealthPaymentEntry.deserializeBinary(entryData)
 
-          let electrumHandler = rootGetters['electrumHandler/getClient']
-
-          let txId = Buffer.from(stealthMessage.getTxId()).toString('hex')
-          try {
-            var txRaw = await electrumHandler.methods.blockchain_transaction_get(txId)
-          } catch (err) {
-            console.error(err)
-            // TODO: Awaiting confirmation check
-            // TODO: Logic relating to this
+          // Add stealth outputs
+          const outpointsList = stealthMessage.getOutpointsList()
+          const ephemeralPubKeyRaw = stealthMessage.getEphemeralPubKey()
+          const ephemeralPubKey = PublicKey.fromBuffer(ephemeralPubKeyRaw)
+          let totalSatoshis = 0
+          for (const [, outpoint] of Object.entries(outpointsList)) {
+            const stealthTxRaw = Buffer.from(outpoint.getStealthTx())
+            const stealthTx = cashlib.Transaction(stealthTxRaw)
+            const txId = stealthTx.hash
+            const vouts = outpoint.getVoutsList()
+            for (const outputIndex of vouts) {
+              const output = stealthTx.outputs[outputIndex]
+              const satoshis = output.satoshis
+              totalSatoshis += satoshis
+              if (!outbound) {
+                continue
+                // We don't want to add these to the wallet, but we do want the total
+              }
+              const outputPrivKey = constructStealthPrivKey(ephemeralPubKey, identityPrivKey)
+              const address = output.script.toAddress('testnet').toLegacyAddress() // TODO: Make generic
+              const stampOutput = {
+                address,
+                satoshis,
+                outputIndex,
+                privKey: outputPrivKey,
+                txId,
+                type: 'stealth',
+                payloadDigest
+              }
+              dispatch('wallet/addUTXO', stampOutput, { root: true })
+            }
           }
-          let tx = cashlib.Transaction(txRaw)
-
-          // Add stealth output
-          let output = tx.outputs[0]
-          let address = output.script.toAddress('testnet').toLegacyAddress() // TODO: Make generic
-          let ephemeralPubKeyRaw = stealthMessage.getEphemeralPubKey()
-          const ephemeralPubKey = PublicKey(ephemeralPubKeyRaw)
-          const privKey = constructStealthPrivKey(ephemeralPubKey, identityPrivKey)
-
-          let stealthOutput = {
-            address,
-            outputIndex: 0, // TODO: 0 is always stealth output, change this assumption?
-            satoshis: output.satoshis,
-            txId,
-            type: 'stealth',
-            privKey
-          }
-          dispatch('wallet/addUTXO', stealthOutput, { root: true })
           newMsg.items.push({
             type: 'stealth',
-            amount: output.satoshis
+            amount: totalSatoshis
           })
         } else if (kind === 'image') {
           let image = imageUtil.entryToImage(entry)

--- a/src/store/modules/wallet.js
+++ b/src/store/modules/wallet.js
@@ -1,7 +1,6 @@
 import Vue from 'vue'
 
 import { numAddresses, numChangeAddresses } from '../../utils/constants'
-
 import formatting from '../../utils/formatting'
 import { calcId } from '../../utils/wallet'
 


### PR DESCRIPTION
In an effort to obfuscate transaction amounts, we have added bundling
to the stealth entries. This allows transfered amounts to be split
over multiple bitcoin cash transactions.

This commit adds support for the new protobuf specification that allows
that. It supports on the receiving end arbitrary splits, but on the
sending end only does one output and one transaction currently.