### PR TITLE
Catch error on deserializing message payload and continue

### DIFF
--- a/src/store/modules/chats.js
+++ b/src/store/modules/chats.js
@@ -728,12 +728,15 @@ export default {
 
         // TODO: Check correct destination
         // let destPubKey = timedMessage.getDestination()
-
-        let serverTime = timedMessage.getServerTime()
-        let receivedTime = Date.now()
-        let message = timedMessage.getMessage()
-        await dispatch('receiveMessage', { serverTime, receivedTime, message })
-        lastReceived = Math.max(lastReceived, receivedTime)
+        try {
+          let serverTime = timedMessage.getServerTime()
+          let receivedTime = Date.now()
+          let message = timedMessage.getMessage()
+          await dispatch('receiveMessage', { serverTime, receivedTime, message })
+          lastReceived = Math.max(lastReceived, receivedTime)
+        } catch (err) {
+          console.error('Unable to deserialize message for some reason', err)
+        }
       }
       if (lastReceived) {
         commit('setLastReceived', lastReceived + 1)


### PR DESCRIPTION
For some reason, the relay server is sending an invalid message payload
occasionally. This commit swaps the deserialization in a try/catch block
so that we can continue to read further messages.