### PR TITLE
Make sure reply payload is a buffer before trying to serialize

### DIFF
--- a/src/relay/constructors.js
+++ b/src/relay/constructors.js
@@ -127,7 +127,7 @@ export const constructPayload = function (entries, privKey, destPubKey, scheme, 
 const constructReplyEntry = function (payloadDigest) {
   let entry = new messaging.Entry()
   entry.setKind('reply')
-  entry.setEntryData(payloadDigest)
+  entry.setEntryData(Buffer.from(payloadDigest))
   return entry
 }
 

--- a/src/store/modules/chats.js
+++ b/src/store/modules/chats.js
@@ -637,7 +637,7 @@ export default {
         // If addr data doesn't exist then add it
         let kind = entry.getKind()
         if (kind === 'reply') {
-          let payloadDigest = entry.entryData()
+          let payloadDigest = Buffer.from(entry.entryData())
           newMsg.items.push({
             type: 'reply',
             payloadDigest


### PR DESCRIPTION
Leaving payloadDigest as a string causes protobuf serialization errors.
This commit addresses that problem by first turning it into a buffer
before setting the key.