### PR TITLE
Fetch reply digest from reply entry using correct getter

### DIFF
--- a/src/store/modules/chats.js
+++ b/src/store/modules/chats.js
@@ -637,7 +637,7 @@ export default {
         // If addr data doesn't exist then add it
         let kind = entry.getKind()
         if (kind === 'reply') {
-          let payloadDigest = Buffer.from(entry.entryData())
+          let payloadDigest = Buffer.from(entry.getEntryData())
           newMsg.items.push({
             type: 'reply',
             payloadDigest


### PR DESCRIPTION
This commit fixes the getter call for the reply digest when receiving
messages.