### PR TITLE
Change protocol for determining stamp UTXO keys

### DIFF
--- a/src/relay/constructors.js
+++ b/src/relay/constructors.js
@@ -9,11 +9,20 @@ import wrapper from '../pop/wrapper_pb'
 
 const cashlib = require('bitcore-lib-cash')
 
-export const constructStampTransaction = async function (outpointDigest, destPubKey, amount) {
+export const constructStampTransaction = async function (payloadDigest, destPubKey, amount) {
   // Stamp output
-  let stampAddress = constructStampPubKey(outpointDigest, destPubKey).toAddress('testnet')
+  let stampHDPubKey = constructStampPubKey(payloadDigest, destPubKey)
+  // Assuming one txn and one output for now.
+  const transactionNumber = 0// This should be the index of the transaction in the outpoint list
+  const outputNumber = 0 // This should the index in the outpoint list *NOT* the vout.  Otherwise they can't be reordered before signing
+
+  const outpointPubKey = stampHDPubKey.deriveChild(44)
+    .deriveChild(145)
+    .deriveChild(transactionNumber)
+    .deriveChild(outputNumber)
+    .publicKey
   let stampOutput = new cashlib.Transaction.Output({
-    script: cashlib.Script(new cashlib.Address(stampAddress)),
+    script: cashlib.Script(new cashlib.Address(outpointPubKey)),
     satoshis: amount
   })
 
@@ -54,20 +63,6 @@ export const constructStealthTransaction = async function (ephemeralPrivKey, des
   return [{ transaction, vouts: [0], usedIDs }]
 }
 
-export const constructOutpointDigest = function (stampNum, vout, payloadDigest) {
-  // TODO: Bounds checks?
-  let stampNumRaw = new Uint8Array(new Uint32Array([stampNum]).buffer)
-  let voutRaw = new Uint8Array(new Uint32Array([vout]).buffer)
-
-  let preimage = new Uint8Array(8 + payloadDigest.length)
-  preimage.set(stampNumRaw)
-  preimage.set(voutRaw, 4)
-  preimage.set(payloadDigest, 8)
-
-  let digest = cashlib.crypto.Hash.sha256(preimage)
-  return digest
-}
-
 export const constructMessage = async function (payload, privKey, destPubKey, stampAmount) {
   let serializedPayload = payload.serializeBinary()
   let payloadDigest = cashlib.crypto.Hash.sha256(serializedPayload)
@@ -81,8 +76,7 @@ export const constructMessage = async function (payload, privKey, destPubKey, st
   message.setSignature(sig)
   message.setSerializedPayload(serializedPayload)
 
-  let outpointDigest = constructOutpointDigest(0, 0, payloadDigest)
-  let { transaction, usedIDs } = await constructStampTransaction(outpointDigest, destPubKey, stampAmount)
+  let { transaction, usedIDs } = await constructStampTransaction(payloadDigest, destPubKey, stampAmount)
   let rawStampTx = transaction.toBuffer()
   let stampOutpoints = new messaging.StampOutpoints()
   stampOutpoints.setStampTx(rawStampTx)

--- a/src/relay/crypto.js
+++ b/src/relay/crypto.js
@@ -41,20 +41,33 @@ export const constructStealthPrivKey = function (emphemeralPubKey, privKey) {
 }
 
 export const constructStampPubKey = function (outpointDigest, destPubKey) {
-  let digestPrivateKey = PrivateKey.fromBuffer(outpointDigest)
-  let digestPublicKey = digestPrivateKey.toPublicKey()
-
-  let stampPoint = digestPublicKey.point.add(destPubKey.point)
-  let stampPublicKey = PublicKey.fromPoint(stampPoint)
-
-  return stampPublicKey
+  const digestPrivateKey = PrivateKey.fromBuffer(outpointDigest)
+  const digestPublicKey = digestPrivateKey.toPublicKey()
+  const stampPoint = digestPublicKey.point.add(destPubKey.point)
+  const stampPublicKey = PublicKey.fromPoint(stampPoint)
+  return new cashlib.HDPublicKey({
+    publicKey: stampPublicKey.toBuffer(),
+    depth: 0,
+    network: 'testnet',
+    childIndex: 0,
+    chainCode: outpointDigest.slice(0, 32),
+    parentFingerPrint: 0
+  })
 }
 
 export const constructStampPrivKey = function (outpointDigest, privKey) {
-  let digestBn = cashlib.crypto.BN.fromBuffer(outpointDigest)
-  let stampPrivBn = privKey.bn.add(digestBn).mod(cashlib.crypto.Point.getN())
-  let stampPrivKey = PrivateKey(stampPrivBn)
-  return stampPrivKey
+  const digestBn = cashlib.crypto.BN.fromBuffer(outpointDigest)
+  const stampPrivBn = privKey.bn.add(digestBn).mod(cashlib.crypto.Point.getN())
+  const stampPrivKey = PrivateKey(stampPrivBn)
+  const key = new cashlib.HDPrivateKey({
+    privateKey: stampPrivKey.toBuffer(),
+    depth: 0,
+    network: 'testnet',
+    childIndex: 0,
+    chainCode: outpointDigest.slice(0, 32),
+    parentFingerPrint: 0
+  })
+  return key
 }
 
 export const constructStampAddress = function (outpointDigest, privKey) {

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -19,8 +19,8 @@ export const defaultFeePerByte = 2
 export const pingTimeout = 20_000
 export const relayReconnectInterval = 10_000
 export const defaultAcceptancePrice = 100
-export const defaultRelayUrl = '34.68.170.199:8532'
-export const relayUrlOptions = ['34.68.170.199:8532', 'bitcoin.com', 'cashweb.io']
+export const defaultRelayUrl = '34.68.170.199:8531'
+export const relayUrlOptions = ['34.68.170.199:8531', 'bitcoin.com', 'cashweb.io']
 export const defaultRelayData = {
   profile: {
     name: '',


### PR DESCRIPTION
The new protocol uses BIP32 derivation for finding out the keys for
each UTXO and transaction. This is less bespoke and has off the shelf
libraries for the calculation. It should make lives easier in the future
for other implementers.