### PR TITLE
Ensure payload is fetched from correct location

### DIFF
--- a/src/store/modules/chats.js
+++ b/src/store/modules/chats.js
@@ -515,7 +515,7 @@ export default {
         let relayClient = rootGetters['relayClient/getClient']
         try {
           let token = rootGetters['relayClient/getToken']
-          rawPayload = new Uint8Array(await relayClient.getRawPayload(senderAddr, token, payloadDigestFromServer))
+          rawPayload = new Uint8Array(await relayClient.getRawPayload(myAddress, token, payloadDigestFromServer))
         } catch (err) {
           console.error(err)
           // TODO: Handle


### PR DESCRIPTION
When a received payload was truncated by the server, this code
woudl only work when it was from yourself. It did not work when
other users were sending you messages due to token validation.