### PR TITLE
Update UTXO selection for better privacy

### DIFF
--- a/src/components/dialogs/SendAddressDialog.vue
+++ b/src/components/dialogs/SendAddressDialog.vue
@@ -87,7 +87,7 @@ export default {
         })
 
         let feePerByte = await this.getFee()
-        var { transaction, usedIDs } = await this.constructTransaction({ outputs: [output], feePerByte })
+        var { transaction, usedIDs } = await this.constructTransaction({ outputs: [output], feePerByte, exactOutputs: true })
         let txHex = transaction.toString()
 
         let electrumHandler = this.getClient()

--- a/src/pages/Setup.vue
+++ b/src/pages/Setup.vue
@@ -357,6 +357,8 @@ export default {
         await this.setUpKeyserver()
       } catch (err) {
         console.error(err)
+        console.error(err.response)
+
         this.$q.loading.hide()
         return
       }
@@ -490,6 +492,7 @@ export default {
         var { token } = await client.sendPayment(paymentUrl, payment)
       } catch (err) {
         console.error(err)
+        console.error(err.response)
         paymentFailureNotify()
         throw err
       }

--- a/src/pop/index.js
+++ b/src/pop/index.js
@@ -56,7 +56,7 @@ export default {
 
     // Construct tx
     let feePerByte = await store.dispatch('wallet/getFee')
-    let { transaction, usedIDs } = await store.dispatch('wallet/constructTransaction', { outputs, feePerByte })
+    let { transaction, usedIDs } = await store.dispatch('wallet/constructTransaction', { outputs, feePerByte, exactOutputs: true })
     let rawTransaction = transaction.toBuffer()
 
     // Send payment and receive token


### PR DESCRIPTION
Attempt to use only one UTXO if possible, and if not attempt to use
UTXOs from as few transactions as possible to avoid co-mingling marked
UTXOs.  Additionally, there's some miner logging fixups which were
required to debug this change.