### PR TITLE
Turn the chat input into its own component

### DIFF
--- a/src/components/chat/ChatInput.vue
+++ b/src/components/chat/ChatInput.vue
@@ -1,0 +1,57 @@
+<template>
+  <div class="row">
+    <q-resize-observer @resize="onResizeInput" />
+    <q-toolbar class="bg-white q-pl-none">
+      <q-btn dense flat color="primary" icon="attach_file" @click="sendFileClicked" />
+      <q-input
+        ref="inputBox"
+        style="width: 100%;"
+        dense
+        borderless
+        autogrow
+        @keydown.enter.prevent="sendMessage"
+        v-bind:value="message"
+        v-on:input="onInput"
+        placeholder="Write a message..."
+      />
+      <q-space />
+        <q-btn  dense flat color="primary" icon="send" @click="sendMessage" />
+    </q-toolbar>
+  </div>
+</template>
+
+<script>
+export default {
+  components: {
+  },
+  data () {
+    return { }
+  },
+  model: {
+    prop: 'message',
+    event: 'input'
+  },
+  props: {
+    message: String
+  },
+  methods: {
+    onInput (event) {
+      this.$emit('input', event)
+    },
+    onResizeInput (size) {
+      this.$emit('resize', size)
+    },
+    sendMessage () {
+      if (this.message === '') {
+        return
+      }
+      this.$emit('sendMessage', this.message)
+    },
+    sendFileClicked () {
+      this.$emit('sendFileClicked')
+    }
+  },
+  computed: {
+  }
+}
+</script>

--- a/src/pages/Chat.vue
+++ b/src/pages/Chat.vue
@@ -49,39 +49,7 @@
       </div>
 
       <!-- Message box -->
-      <div class="row">
-        <q-resize-observer @resize="onResizeInput" />
-        <q-toolbar class="bg-white q-pl-none">
-          <q-btn
-            dense
-            flat
-            color="primary"
-            icon="attach_file"
-            @click="sendFileOpen = true"
-          />
-          <q-input
-            ref="inputBox"
-            style="width: 100%;"
-            dense
-            borderless
-            autogrow
-            @keydown.enter.prevent="sendMessage"
-            v-model="message"
-            placeholder="Write a message..."
-          />
-          <q-space />
-          <transition name="slide">
-            <q-btn
-              v-if="message != ''"
-              dense
-              flat
-              color="primary"
-              icon="send"
-              @click="sendMessage"
-            />
-          </transition>
-        </q-toolbar>
-      </div>
+      <chat-input v-model="message" @resize="onResizeInput" @sendMessage="sendMessage" @sendFileClicked="sendFileClicked" />
     </div>
     <q-page-sticky
       position="top-right"
@@ -103,6 +71,7 @@
 
 <script>
 import { mapGetters, mapActions } from 'vuex'
+import ChatInput from '../components/chat/ChatInput.vue'
 import ChatMessage from '../components/chat/ChatMessage.vue'
 import SendFileDialog from '../components/dialogs/SendFileDialog.vue'
 import ChatMessageReply from '../components/chat/ChatMessageReply.vue'
@@ -115,7 +84,8 @@ export default {
   components: {
     ChatMessage,
     SendFileDialog,
-    ChatMessageReply
+    ChatMessageReply,
+    ChatInput
   },
   data () {
     return {
@@ -133,10 +103,10 @@ export default {
       setInputMessage: 'chats/setInputMessage',
       setCurrentReply: 'chats/setCurrentReply'
     }),
-    sendMessage () {
-      if (this.message !== '') {
+    sendMessage (message) {
+      if (message !== '') {
         let replyDigest = this.getCurrentReplyDigest(this.activeChat)
-        this.sendMessageVuex({ addr: this.activeChat, text: this.message, replyDigest })
+        this.sendMessageVuex({ addr: this.activeChat, text: message, replyDigest })
         this.message = ''
         this.setCurrentReply({ addr: this.activeChat, index: null })
         this.$nextTick(() => this.$refs.inputBox.focus())
@@ -154,6 +124,9 @@ export default {
     },
     onResizeReply (size) {
       this.replyHeight = size.height
+    },
+    sendFileClicked () {
+      this.sendFileOpen = true
     },
     getContact (outbound) {
       if (outbound) {
@@ -185,7 +158,7 @@ export default {
         this.setInputMessage({ addr: this.activeChat, text })
       },
       get () {
-        return this.getInputMessage(this.activeChat)
+        return this.getInputMessage(this.activeChat) || ''
       }
     },
     replyItem () {


### PR DESCRIPTION
This commit moves the chat input box into its own component so that
it may be duplicated in other parts of the code. It also removes
the dependencies on global state.