### PR TITLE
Make chat area not re-render when switching tabs

### DIFF
--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -5,9 +5,9 @@
     </q-dialog>
     <my-drawer />
     <contact-drawer
-      v-if="getActiveChat !== null"
-      :address="getActiveChat"
-      :contact="getContact(getActiveChat)"
+      v-if="activeChatAddr !== null"
+      :address="activeChatAddr"
+      :contact="getContact(activeChatAddr)"
     />
     <main-header>
       <q-resize-observer @resize="onResize" />
@@ -24,11 +24,14 @@
         </template>
 
         <template v-slot:after>
-          <chat
+          <template v-for="(item, index) in data">
+          <chat v-show="activeChatAddr === index"
+            :key="index"
             :tabHeight="tabHeight"
-            :activeChat="getActiveChat"
-            :messages="getAllMessages(getActiveChat)"
+            :activeChat="activeChatAddr"
+            :messages="item.messages"
           />
+          </template>
         </template>
 
       </q-splitter>
@@ -43,7 +46,7 @@ import MyDrawer from '../components/drawers/MyDrawer.vue'
 import ContactDrawer from '../components/drawers/ContactDrawer.vue'
 import MainHeader from '../components/MainHeader.vue'
 import WalletConnectDialog from '../components/dialogs/WalletConnectDialog.vue'
-import { mapActions, mapGetters } from 'vuex'
+import { mapActions, mapGetters, mapState } from 'vuex'
 import { dom } from 'quasar'
 const { height } = dom
 import { minSplitter, maxSplitter } from '../utils/constants'
@@ -88,13 +91,12 @@ export default {
     }
   },
   computed: {
+    ...mapState('chats', ['data', 'activeChatAddr']),
     ...mapGetters({
       getToken: 'relayClient/getToken',
       getRelayClient: 'relayClient/getClient',
       getAddressStr: 'wallet/getMyAddressStr',
-      getActiveChat: 'chats/getActiveChat',
       getContact: 'contacts/getContact',
-      getAllMessages: 'chats/getAllMessages',
       walletConnected: 'electrumHandler/connected'
     }),
     ...mapGetters({ getSplitterRatio: 'splitter/getSplitterRatio' }),

--- a/src/store/modules/chats.js
+++ b/src/store/modules/chats.js
@@ -147,13 +147,6 @@ export default {
         return info
       }
     },
-    getAllMessages: (state) => (addr) => {
-      if (addr in state.data) {
-        return state.data[addr].messages
-      } else {
-        return {}
-      }
-    },
     getLastReceived (state) {
       return state.lastReceived
     },


### PR DESCRIPTION
Herin we render multiple chat components for each contact, but only
show the active one. This ensures these chats aren't re-rendered when
switching contacts. This is at the expense of memory and initial load
times. However, much of this can be obviated with more adjustments to
how vuex is being used.