### PR TITLE
Remove use of tabHeight to fix heights in layout

### DIFF
--- a/src/components/chat/ChatList.vue
+++ b/src/components/chat/ChatList.vue
@@ -53,7 +53,7 @@
     <q-separator />
     <q-scroll-area
       class="q-px-none row"
-      :style="`height: calc(100vh - ${balanceHeight}px - ${tabHeight}px);`"
+      :style="`min-height:calc(100% - 51px); height: calc(100% - 51px);`"
     >
       <chat-list-item
         v-for="(contact) in getSortedChatOrder"
@@ -80,7 +80,7 @@ import WalletConnectDialog from '../dialogs/WalletConnectDialog.vue'
 import RelayConnectDialog from '../dialogs/RelayConnectDialog.vue'
 
 export default {
-  props: ['tabHeight', 'chatAddr'],
+  props: ['chatAddr'],
   components: {
     ChatListItem,
     WalletDialog,
@@ -89,16 +89,12 @@ export default {
   },
   data () {
     return {
-      balanceHeight: 100,
       walletOpen: false,
       walletConnectOpen: false,
       relayConnectOpen: false
     }
   },
   methods: {
-    onResize (size) {
-      this.height = size.height
-    },
     formatBalance (balance) {
       if (!balance) {
         return balance

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -13,28 +13,33 @@
       <q-resize-observer @resize="onResize" />
     </main-header>
     <q-page-container>
-      <q-splitter
-        emit-immediately
-        v-model="splitterRatio"
-        separator-style="width: 0px"
-        :limits="[minSplitter, maxSplitter]"
-      >
-        <template v-slot:before>
-          <chat-list :tabHeight="tabHeight" />
-        </template>
-
-        <template v-slot:after>
-          <template v-for="(item, index) in data">
-          <chat v-show="activeChatAddr === index"
-            :key="index"
-            :tabHeight="tabHeight"
-            :activeChat="activeChatAddr"
-            :messages="item.messages"
-          />
+      <q-page :style-fn="tweak">
+        <q-splitter
+          emit-immediately
+          v-model="splitterRatio"
+          separator-style="width: 0px"
+          :limits="[minSplitter, maxSplitter]"
+          :style="`height: inherit; min-height: inherit;`"
+        >
+          <template v-slot:before :style="`height: 100%; min-height: 100%;`">
+            <chat-list :style="`height: 100%; min-height: 100%;`" />
           </template>
-        </template>
 
-      </q-splitter>
+          <template
+            v-slot:after
+          >
+            <template v-for="(item, index) in data">
+              <chat
+                v-show="activeChatAddr === index"
+                :key="index"
+                :activeChat="activeChatAddr"
+                :messages="item.messages"
+                :style="`height: inherit; min-height: inherit;`"
+              />
+            </template>
+          </template>
+        </q-splitter>
+      </q-page>
     </q-page-container>
   </q-layout>
 </template>
@@ -88,6 +93,10 @@ export default {
     }),
     onResize (size) {
       this.tabHeight = height(this.$refs.tabs.$el)
+    },
+    tweak (offset, viewportHeight) {
+      const height = viewportHeight - offset + 'px'
+      return { height, minHeight: height }
     }
   },
   computed: {


### PR DESCRIPTION
This commit removes the need to pass around and use tabHeight within
the components of the layout by ensuring the outer containers are all
set to max height. Additionally, the q-page component is set to the
maximum size view a `style-fn` which receives the viewport header/footer
size as an offset.