### PR TITLE
Fix missed reference to old chat input

### DIFF
--- a/src/pages/Chat.vue
+++ b/src/pages/Chat.vue
@@ -119,7 +119,7 @@ export default {
         this.sendMessageVuex({ addr: this.activeChat, text: message, replyDigest })
         this.message = ''
         this.setCurrentReply({ addr: this.activeChat, index: null })
-        this.$nextTick(() => this.$refs.inputBox.focus())
+        this.$nextTick(() => this.$refs.chatInput.$el.focus())
       }
     },
     scrollBottom () {


### PR DESCRIPTION
As per title. Use the correct reference for focusing the chat input.