### PR TITLE
Delete unused code leftover from previous cleanups

### DIFF
--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -67,7 +67,6 @@ export default {
   },
   data () {
     return {
-      tabHeight: 50,
       minSplitter,
       maxSplitter,
       walletConnectOpen: false

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -10,8 +10,6 @@ const vuexLocal = new VuexPersistence({
   filter: (mutation) => {
     let namespace = mutation.type.split('/')[0]
     switch (namespace) {
-      case 'clock':
-        return false
       case 'contactDrawer':
         return false
       case 'myDrawer':


### PR DESCRIPTION
As per title. Delete reference to clock and tabHeight.