### PR TITLE
Ensure stamp prices are re-imported from seed on outboud messages

### DIFF
--- a/src/store/modules/chats.js
+++ b/src/store/modules/chats.js
@@ -588,22 +588,22 @@ export default {
       const stampOutpoints = message.getStampOutpointsList()
       const outpoints = []
 
-      if (!outbound) {
-        const stampRootHDPrivKey = constructStampPrivKey(payloadDigest, identityPrivKey)
-          .deriveChild(44)
-          .deriveChild(145)
+      const stampRootHDPrivKey = constructStampPrivKey(payloadDigest, identityPrivKey)
+        .deriveChild(44)
+        .deriveChild(145)
 
-        for (const [i, stampOutpoint] of stampOutpoints.entries()) {
-          const stampTxRaw = Buffer.from(stampOutpoint.getStampTx())
-          const stampTx = cashlib.Transaction(stampTxRaw)
-          const txId = stampTx.hash
-          const vouts = stampOutpoint.getVoutsList()
-          outpoints.push({
-            stampTx,
-            vouts
-          })
-          const stampTxHDPrivKey = stampRootHDPrivKey.deriveChild(i)
+      for (const [i, stampOutpoint] of stampOutpoints.entries()) {
+        const stampTxRaw = Buffer.from(stampOutpoint.getStampTx())
+        const stampTx = cashlib.Transaction(stampTxRaw)
+        const txId = stampTx.hash
+        const vouts = stampOutpoint.getVoutsList()
+        outpoints.push({
+          stampTx,
+          vouts
+        })
+        const stampTxHDPrivKey = stampRootHDPrivKey.deriveChild(i)
 
+        if (!outbound) {
           for (const [j, outputIndex] of vouts.entries()) {
             const output = stampTx.outputs[outputIndex]
             const satoshis = output.satoshis


### PR DESCRIPTION
Currently, if you delete your state and reimport your key, your outboud
messages will not show a stamp price. This commit fixes that by ensuring
that these messages have their outpoints stored with them.