### PR TITLE
Fix unread message functionality

### DIFF
--- a/src/pages/Chat.vue
+++ b/src/pages/Chat.vue
@@ -109,7 +109,6 @@ export default {
   },
   methods: {
     ...mapActions({
-      readAll: 'chats/readAll',
       sendMessageVuex: 'chats/sendMessage'
     }),
     sendMessage (message) {
@@ -175,14 +174,6 @@ export default {
       console.log(msg)
       const firstNonReply = msg.items.find(item => item.type !== 'reply')
       return firstNonReply
-    }
-  },
-  watch: {
-    messages: function (newMsgs, oldMsgs) {
-      this.scrollBottom()
-      if (Object.entries(newMsgs).length !== 0) {
-        this.readAll(this.address)
-      }
     }
   }
 }

--- a/src/store/modules/chats.js
+++ b/src/store/modules/chats.js
@@ -223,14 +223,15 @@ export default {
     readAll ({ commit }, addr) {
       commit('readAll', addr)
     },
-    shareContact ({ commit, rootGetters }, { currentAddr, shareAddr }) {
+    shareContact ({ commit, rootGetters, dispatch }, { currentAddr, shareAddr }) {
       let contact = rootGetters['contacts/getContactProfile'](currentAddr)
       let text = 'Name: ' + contact.name + '\n' + 'Address: ' + currentAddr
       commit('setInputMessage', { addr: shareAddr, text })
-      commit('switchChatActive', shareAddr)
+      dispatch('switchChatActive', shareAddr)
     },
     switchChatActive ({ commit }, addr) {
       commit('switchChatActive', addr)
+      commit('readAll', addr)
     },
     startChatUpdater ({ dispatch }) {
       setInterval(() => { dispatch('refresh') }, 1_000)


### PR DESCRIPTION
While changing the behavior of active chats, we inadvertantely broke
the unread message functionality. This commit fixes it by moving the
dispatch of readAll to the store, where the activeChat is switched.