### PR TITLE
Add a hack to enable state migrations

### DIFF
--- a/src/store/index.js
+++ b/src/store/index.js
@@ -2,11 +2,27 @@ import Vue from 'vue'
 import Vuex from 'vuex'
 import VuexPersistence from 'vuex-persist'
 import modules from './modules'
+import { rehydateChat } from './modules/chats'
 
 Vue.use(Vuex)
 
+const parseState = (value) => {
+  if (typeof value === 'string') { // If string, parse, or else, just return
+    return (JSON.parse(value || '{}'))
+  } else {
+    return (value || {})
+  }
+}
+
 const vuexLocal = new VuexPersistence({
   storage: window.localStorage,
+  // Hack to allow us to easily rehydrate the store
+  restoreState: (key, storage) => {
+    const value = (storage).getItem(key)
+    const newState = parseState(value)
+    rehydateChat(newState.chats)
+    return newState
+  },
   filter: (mutation) => {
     let namespace = mutation.type.split('/')[0]
     switch (namespace) {

--- a/src/store/modules/chats.js
+++ b/src/store/modules/chats.js
@@ -26,6 +26,20 @@ function calculateUnreadAggregates (state, addr) {
   }
 }
 
+export function rehydateChat (chats) {
+  if (!chats) {
+    return
+  }
+
+  if (!chats.data) {
+    for (const contactAddress in chats.data) {
+      const contact = chats.data[contactAddress]
+      contact.address = contactAddress
+      // Do nothing for now
+    }
+  }
+}
+
 export default {
   namespaced: true,
   state: {


### PR DESCRIPTION
This should allow migrating and rehydrating data more easily and quickly.
By doing it prior to replaceState, there won't be any nasty reactive
updates every time something is rehydrated.