### PR TITLE
Rehydrate wallet within the vuex-persist module before components loaded

### DIFF
--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -70,7 +70,6 @@ export default {
   },
   methods: {
     ...mapActions({
-      walletRehydrate: 'wallet/rehydrate',
       electrumRehydrate: 'electrumHandler/rehydrate',
       electrumConnect: 'electrumHandler/connect',
       electrumKeepAlive: 'electrumHandler/keepAlive',
@@ -114,9 +113,6 @@ export default {
     this.electrumRehydrate()
     this.electrumConnect()
     this.electrumKeepAlive()
-
-    // Rehydrate wallet classes
-    this.walletRehydrate()
 
     // Rehydrate relay client
     this.relayClientRehydrate()

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -3,6 +3,7 @@ import Vuex from 'vuex'
 import VuexPersistence from 'vuex-persist'
 import modules from './modules'
 import { rehydateChat } from './modules/chats'
+import { rehydrateWallet } from './modules/wallet'
 
 Vue.use(Vuex)
 
@@ -21,6 +22,7 @@ const vuexLocal = new VuexPersistence({
     const value = (storage).getItem(key)
     const newState = parseState(value)
     rehydateChat(newState.chats)
+    rehydrateWallet(newState.wallet)
     return newState
   },
   filter: (mutation) => {


### PR DESCRIPTION
This commit moves the wallet rehydration to the vuex-persist layer
before any components are loaded. This avoids a bunch of reactive events
from being progressively fired.