### PR TITLE
Fix reset of the chatarea height when not shown

### DIFF
--- a/src/pages/Chat.vue
+++ b/src/pages/Chat.vue
@@ -149,7 +149,9 @@ export default {
       // TODO: This isn't reactive enough. It's somewhat slow to recalculate
       const inputBoxHeight = this.$refs.chatInput ? height(this.$refs.chatInput.$el) : 50
       const replyHeight = this.$refs.replyBox ? height(this.$refs.replyBox) : 0
-      return inputBoxHeight + replyHeight
+      // Sometimes this returns zero when the component isnt' shown. However, it then dates some time to update properly when switching to it.
+      // Set a minimum of 50.
+      return Math.max(inputBoxHeight + replyHeight, 50)
     },
     setReply ({ address, index }) {
       // Address is not useful here as all the stuff in this component is for the same address


### PR DESCRIPTION
When the time is updated, the height of the chatboxes are also
reactively updated. However, since the contents are not shown the
chat input has a height of zero. This causes the chat message box
to take 100% of the viewport. When switching back to hidden viewports
it takes awhile for it to update again. This looks bad.

As a temporary fix, we set the minimum value to 50 (which is the same)
as the chat input on most devices.