### PR TITLE
Remote deletion

### DIFF
--- a/src/components/chat/ChatMessage.vue
+++ b/src/components/chat/ChatMessage.vue
@@ -12,6 +12,7 @@
       :id="index"
       :message="message"
       @txClick="transactionDialog = true"
+      @deleteClick="deleteDialog = true"
       @replyClick="replyClicked({ address, index })"
     />
 
@@ -21,6 +22,14 @@
       <transaction-dialog
         title="Stamp Transaction"
         :outpoints="message.outpoints"
+      />
+    </q-dialog>
+
+    <!-- Delete Dialog -->
+    <q-dialog v-model="deleteDialog">
+      <delete-message-dialog
+        :address="address"
+        :index="index"
       />
     </q-dialog>
 
@@ -52,6 +61,7 @@
 import moment from 'moment'
 import ChatMessageSection from './ChatMessageSection.vue'
 import ChatMessageMenu from '../context_menus/ChatMessageMenu.vue'
+import DeleteMessageDialog from '../dialogs/DeleteMessageDialog'
 import TransactionDialog from '../dialogs/TransactionDialog.vue'
 import { stampPrice } from '../../wallet/helpers'
 
@@ -59,11 +69,13 @@ export default {
   components: {
     ChatMessageSection,
     ChatMessageMenu,
-    TransactionDialog
+    TransactionDialog,
+    DeleteMessageDialog
   },
   data () {
     return {
-      transactionDialog: false
+      transactionDialog: false,
+      deleteDialog: false
     }
   },
   props: {

--- a/src/components/context_menus/ChatMessageMenu.vue
+++ b/src/components/context_menus/ChatMessageMenu.vue
@@ -50,7 +50,7 @@
       <q-item
         clickable
         v-close-popup
-        @click="deleteMessage({ addr: address, id })"
+        @click="$emit('deleteClick')"
       >
         <q-item-section>Delete</q-item-section>
       </q-item>

--- a/src/components/dialogs/DeleteMessageDialog.vue
+++ b/src/components/dialogs/DeleteMessageDialog.vue
@@ -1,0 +1,55 @@
+<template>
+  <q-card>
+    <q-card-section class="row items-center">
+      <q-avatar
+        icon="delete"
+        color="red"
+        text-color="white"
+      />
+      <span class="q-ml-sm">Are you sure you want to delete this message?</span>
+    </q-card-section>
+
+    <q-card-actions align="right">
+      <q-btn
+        flat
+        label="Cancel"
+        color="primary"
+        v-close-popup
+      />
+      <q-btn
+        flat
+        label="Delete"
+        color="primary"
+        v-close-popup
+        @click="deleteMessageBoth()"
+      />
+    </q-card-actions>
+  </q-card>
+</template>
+
+<script>
+import { mapActions } from 'vuex'
+export default {
+  props: ['address', 'index'],
+  methods: {
+    ...mapActions({
+      deleteMessage: 'chats/deleteMessage'
+    }),
+    async deleteMessageBoth () {
+      // TODO: Move this into wallet API
+      // TODO: More private
+      // Delete message from relay server
+      await this.$relayClient.deleteMessage(this.index)
+      // Delete message from relay server
+      try {
+        this.deleteMessage({ addr: this.address, id: this.index })
+      } catch (err) {
+        console.error(err)
+        if (err.response) {
+          console.error(err.response)
+        }
+      }
+    }
+  }
+}
+</script>


### PR DESCRIPTION
**Motiviation**
Users should be able to delete messages from the remote server, not just locally.

**Implementation**
A dialog box prompts the user whether they'd like to delete.

On confirmation, Stamp will forward the UTXOs attached to this message (if they are unspent) to a change address for safe keeping. It will then proceed to delete using the new DELETE API on the relay server. 

**Notes**
The `forwardTransaction` constructor method is very simplistic and will need to be tweaked in order to preserve privacy. Furthermore, it should be extracted out of the store along with `constructTransaction` in the near future.