### PR TITLE
Update contacts on demand rather than on a timer

### DIFF
--- a/src/components/dialogs/SettingsDialog.vue
+++ b/src/components/dialogs/SettingsDialog.vue
@@ -25,7 +25,7 @@
 </template>
 
 <script>
-import { mapGetters, mapActions } from 'vuex'
+import { mapGetters, mapActions, mapMutations } from 'vuex'
 import Settings from '../Settings.vue'
 
 export default {
@@ -47,8 +47,10 @@ export default {
   methods: {
     ...mapGetters({ getUpdateInterval: 'contacts/getUpdateInterval', getDarkMode: 'appearance/getDarkMode' }),
     ...mapActions({
-      updateInterval: 'contacts/setUpdateInterval',
       darkMode: 'appearance/setDarkMode'
+    }),
+    ...mapMutations({
+      updateInterval: 'contacts/setUpdateInterval'
     }),
     save () {
       this.darkMode(this.settings.appearance.darkMode)

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -73,7 +73,6 @@ export default {
       electrumConnect: 'electrumHandler/connect',
       electrumKeepAlive: 'electrumHandler/keepAlive',
       relayClientRehydrate: 'relayClient/rehydrate',
-      startContactUpdater: 'contacts/startContactUpdater',
       refreshChat: 'chats/refresh',
       updateHDUTXOs: 'wallet/updateHDUTXOs',
       fixFrozenUTXOs: 'wallet/fixFrozenUTXOs',
@@ -166,9 +165,6 @@ export default {
     this.$q.loading.hide()
 
     console.log('loaded')
-
-    // Start contact watcher
-    this.startContactUpdater()
 
     this.loaded = true
   }

--- a/src/pages/Setup.vue
+++ b/src/pages/Setup.vue
@@ -176,7 +176,7 @@
 <script>
 import Vue from 'vue'
 import VueRouter from 'vue-router'
-import { mapActions, mapGetters } from 'vuex'
+import { mapActions, mapGetters, mapMutations } from 'vuex'
 import KeyserverHandler from '../keyserver/handler'
 import pop from '../pop/index'
 import RelayClient from '../relay/client'
@@ -257,7 +257,6 @@ export default {
       resetWallet: 'wallet/reset',
       setSeedPhrase: 'wallet/setSeedPhrase',
       resetChats: 'chats/reset',
-      updateInterval: 'contacts/setUpdateInterval',
       darkMode: 'appearance/setDarkMode'
     }),
     ...mapGetters({
@@ -268,6 +267,9 @@ export default {
       getIdentityPrivKey: 'wallet/getIdentityPrivKey',
       getUpdateInterval: 'contacts/getUpdateInterval',
       getDarkMode: 'appearance/getDarkMode'
+    }),
+    ...mapMutations({
+      updateInterval: 'contacts/setUpdateInterval'
     }),
     next () {
       this.$refs.stepper.next()

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -23,13 +23,15 @@ export const defaultRelayUrl = '34.68.170.199:8531'
 export const relayUrlOptions = ['34.68.170.199:8531']
 export const defaultRelayData = {
   profile: {
-    name: '',
-    bio: '',
-    avatar: null
+    name: 'Loading...',
+    bio: null,
+    avatar: null,
+    pubKey: null
   },
   inbox: {
-    acceptancePrice: defaultAcceptancePrice
-  }
+    acceptancePrice: NaN
+  },
+  notify: true
 }
 
 // Chat constants


### PR DESCRIPTION
This commit causes contacts to be updated when they are activated,
rather than on a timer. The update times are cached, and only repolled
when the timeout for a particular contact expires. This leads to less
requests against the backends overall.