### PR TITLE
Don't add totals to unread if chat is active

### DIFF
--- a/src/store/modules/chats.js
+++ b/src/store/modules/chats.js
@@ -234,9 +234,11 @@ export default {
       }
 
       state.data[addr].lastReceived = newMsg.receivedTime
-      state.data[addr].totalUnreadMessages += 1
       const messageValue = stampPrice(newMsg.outpoints) + newMsg.items.reduce((totalValue, { amount = 0 }) => totalValue + amount, 0)
-      state.data[addr].totalUnreadValue += messageValue
+      if (addr !== state.activeChatAddr) {
+        state.data[addr].totalUnreadValue += messageValue
+        state.data[addr].totalUnreadMessages += 1
+      }
       state.data[addr].totalValue += messageValue
     },
     setLastReceived (state, lastReceived) {


### PR DESCRIPTION
Currently, we've been adding to unread message totals even when the
chat the messages are being received for is active. This commit fixes
that issue.