### PR TITLE
Prevent notifications with insufficient fees rather than censor

### DIFF
--- a/src/pages/Chat.vue
+++ b/src/pages/Chat.vue
@@ -131,7 +131,6 @@ export default {
       const acceptancePrice = this.getAcceptancePrice()(this.address)
       if (stampAmount < acceptancePrice) {
         insufficientStampNotify()
-        return
       }
       if (message !== '') {
         this.sendMessageVuex({ addr: this.address, text: message, replyDigest: this.replyDigest })

--- a/src/store/modules/chats.js
+++ b/src/store/modules/chats.js
@@ -625,11 +625,7 @@ export default {
 
       // Ignore messages below acceptance price
       const acceptancePrice = rootGetters['myProfile/getInbox'].acceptancePrice
-      if (stampValue < acceptancePrice) {
-        console.log('ignoring', stampValue, acceptancePrice)
-        return
-      }
-      console.log('accepted')
+      const acceptable = (stampValue >= acceptancePrice)
       let stealthValue = 0
 
       // Decode entries
@@ -663,7 +659,7 @@ export default {
           })
 
           // If not focused (and not outbox message) then notify
-          if (!document.hasFocus() && !outbound) {
+          if (!document.hasFocus() && !outbound && acceptable) {
             let contact = rootGetters['contacts/getContact'](senderAddr)
             if (contact.notify) {
               desktopNotify(contact.profile.name, text, contact.profile.avatar, () => {

--- a/src/utils/notifications.js
+++ b/src/utils/notifications.js
@@ -40,10 +40,6 @@ export const profileTooLargeNotify = function () {
   negativeNotify('Profile is too large.')
 }
 
-export const insufficientStampNotify = function () {
-  negativeNotify('Stamp is too small.')
-}
-
 // Info notifications
 
 const infoNotify = function (text) {
@@ -56,6 +52,10 @@ const infoNotify = function (text) {
 
 export const addressCopiedNotify = function () {
   infoNotify('Address copied to clipboard.')
+}
+
+export const insufficientStampNotify = function () {
+  infoNotify('Stamp is too small, receiver will not be notified.')
 }
 
 export const seedCopiedNotify = function () {


### PR DESCRIPTION
**Motivation**
After some discussion, we concluded that it would be better to not throw out messages with insufficient fees.