### PR TITLE
Update readme to remove protobuf information

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@
 
 ### Requirements
 
-* [Protobuf compiler](https://github.com/protocolbuffers/protobuf)
 * [Quasar](https://quasar.dev/start/pick-quasar-flavour)
 
 ### Cloning the Source
@@ -38,20 +37,21 @@ Clone this repository using
 ```bash
 git clone https://github.com/cashweb/stamp.git
 cd stamp
-git submodule update --init --recursive
 ```
 
-### Generating the Protobuf files
+### Development Mode
+
+Running the following command should run electron in development mode and watch the source files with hot reloading enabled:
 
 ```bash
-bash ./generate_protobufs.sh
+yarn dev
 ```
 
-### Linux, MacOS and Windows
+### Linux, MacOS and Windows Builds
 
 ```bash
 yarn install
-quasar build -m electron -b builder
+yarn build
 ```
 
 Your binary will be located in `/dist/electron/Packaged/` folder.
@@ -88,6 +88,18 @@ quasar build -m capacitor -T android
 
 ```bash
 quasar build -m capacitor -T ios
+```
+
+### Updating the generated protobuf files:
+
+If the protobuf files need to change due to the addition of a new entry type, or some addition, the following commands will allow for the regeneration of these files. 
+Please check them into the repo after they have been generated.
+
+* [Protobuf compiler](https://github.com/protocolbuffers/protobuf)
+
+```bash
+git submodule update --init --recursive
+yarn generate:protobuffers
 ```
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "google-protobuf": "^3.11.2",
     "moment": "^2.24.0",
     "node-forge": "^0.9.1",
-    "protoc": "^1.0.4",
     "quasar": "^1.9.12",
     "ramda": "^0.27.0",
     "vcf": "^2.0.6",
@@ -49,7 +48,8 @@
     "electron-packager": "^14.1.1",
     "eslint": "^5.10.0",
     "eslint-loader": "^2.1.1",
-    "eslint-plugin-vue": "^5.0.0"
+    "eslint-plugin-vue": "^5.0.0",
+    "protoc": "^1.0.4",
   },
   "engines": {
     "node": ">= 10.18.1",


### PR DESCRIPTION
Because we are not checking in the generated protobuf files, we no
longer need most contributors to install protoc or deal with submodules.
I've removed those instructions from the basic flow, and moved them
to the end, as they are only needed when the protos change.