### PR TITLE
Fix race condition on re-load ordering

### DIFF
--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -118,38 +118,28 @@ export default {
 
     console.log('loading')
     // Setup everything at once. This are independent processes
-    await Promise.all([
-      async () => {
-        try {
-          // Rehydrate relay client
-          this.relayClientRehydrate()
+    try {
+      // Rehydrate relay client
+      this.relayClientRehydrate()
 
-          const client = this.getRelayClient
-          client.setUpWebsocket(this.getAddressStr, this.getToken)
-          await this.refreshChat()
-        } catch (err) {
-          console.error(err)
-        }
-      },
-      async () => {
-        try {
-          // Start electrum listeners
-          let addresses = Object.keys(this.getAllAddresses())
-          this.startListeners(addresses)
+      const client = this.getRelayClient
+      client.setUpWebsocket(this.getAddressStr, this.getToken)
+      await this.refreshChat()
+      // Start electrum listeners
+      let addresses = Object.keys(this.getAllAddresses())
+      this.startListeners(addresses)
 
-          // Update UTXOs
-          await this.updateHDUTXOs()
+      // Update UTXOs
+      await this.updateHDUTXOs()
 
-          // Fix frozen UTXOs
-          await this.fixFrozenUTXOs()
+      // Fix frozen UTXOs
+      await this.fixFrozenUTXOs()
 
-          // Fix UTXOs
-          await this.fixUTXOs()
-        } catch (err) {
-          console.error(err)
-        }
-      }
-    ].map(f => f()))
+      // Fix UTXOs
+      await this.fixUTXOs()
+    } catch (err) {
+      console.error(err)
+    }
 
     if (!this.activeChatAddr) {
       const contacts = this.getSortedChatOrder()


### PR DESCRIPTION
When importing an old wallet from seed, there is currently a race
condition between checking UTXO validity, and loading up the chat
history. As such, sometimes we end up in a state where we cannot
generate new valid transactions. This commit de-paralleles the
chat reload and wallet validation steps. A future commit can possibly
address these issues to enhance load times.