### PR TITLE
Remove unused state from wallet vuex store

### DIFF
--- a/src/store/modules/wallet.js
+++ b/src/store/modules/wallet.js
@@ -34,7 +34,6 @@ export default {
   namespaced: true,
   state: {
     xPrivKey: null,
-    identityPrivKey: null,
     utxos: {},
     frozenUTXOs: {},
     feePerByte: 2,
@@ -46,7 +45,6 @@ export default {
     },
     reset (state) {
       state.xPrivKey = null
-      state.identityPrivKey = null
       state.utxos = {}
       state.frozenUTXOs = {}
     },


### PR DESCRIPTION
We no longer save the identity privkey as it is calculated on startup.
This commit removes a few dead lines.