### PR TITLE
Remove spend utxos while syncing

### DIFF
--- a/src/wallet/index.js
+++ b/src/wallet/index.js
@@ -406,4 +406,8 @@ export class Wallet {
     // TODO: Nobody should be calling this outside of the wallet
     return this.storage.addUTXO(utxo)
   }
+  removeUTXO (id) {
+    // TODO: Nobody should be calling this outside of the wallet
+    return this.storage.removeUTXO(id)
+  }
 }


### PR DESCRIPTION
Currently, we add all UTXOs we've received while syncing, and then
run through them vs the electrum server. This requires that we slam
the electrum server asking for histories for ever address we've ever
used. This is not scalable, and is particularly inefficient. Instead, we
can simply remove anything we've recorded as being spent from our UTXO
set.