### PR TITLE
Add `bluebird` library to limit promise resolution concurrency

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "axios": "^0.18.1",
     "bip39": "^3.0.2",
     "bitcore-lib-cash": "^8.14.4",
+    "bluebird": "^3.7.2",
     "electrum-cash": "^1.0.1",
     "google-protobuf": "^3.11.2",
     "moment": "^2.24.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2946,7 +2946,7 @@ bluebird-lst@^1.0.9:
   dependencies:
     bluebird "^3.5.5"
 
-bluebird@^3.1.1, bluebird@^3.5.0, bluebird@^3.5.5:
+bluebird@^3.1.1, bluebird@^3.5.0, bluebird@^3.5.5, bluebird@^3.7.2:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==


### PR DESCRIPTION
Currently, we are resolving promises for some wallet operations all
at once. This can generate a storm of requests to electrum servers,
resulting in bans. This commit adds the `bluebird` library and uses its
`P.map` functionality with a concurrency parameter to limit this to
some extent.