### PR TITLE
Improve setup validation

### DIFF
--- a/src/pages/Setup.vue
+++ b/src/pages/Setup.vue
@@ -541,7 +541,7 @@ export default {
       return ((this.seedData.type === 'new') || (this.seedData.type === 'import' && this.seedData.valid))
     },
     isRelayValid () {
-      return [this.relayData.profile.name && this.relayData.profile.avatar && this.relayData.inbox.acceptancePrice].every(Boolean)
+      return !!(this.relayData.profile.name && this.relayData.profile.avatar && this.relayData.inbox.acceptancePrice)
     }
   },
   async created () {

--- a/src/pages/Setup.vue
+++ b/src/pages/Setup.vue
@@ -75,7 +75,7 @@
               @click="nextWallet()"
               color="primary"
               :label="seedData.type==='new'?'New Wallet':'Import Wallet'"
-              :disable="!(electrumConnected && ((seedData.type === 'new') || (seedData.type === 'import' && seedData.valid)))"
+              :disable="!electrumConnected || !isWalletValid"
             />
             <q-btn
               v-else-if="step === 3"
@@ -95,7 +95,7 @@
               v-else-if="step === 5"
               @click="nextRelay()"
               color="primary"
-              :disable="!electrumConnected"
+              :disable="!electrumConnected || !isRelayValid"
               label="Continue"
             />
             <q-btn
@@ -536,6 +536,12 @@ export default {
   computed: {
     electrumConnected () {
       return this.$electrum.connected
+    },
+    isWalletValid () {
+      return ((this.seedData.type === 'new') || (this.seedData.type === 'import' && this.seedData.valid))
+    },
+    isRelayValid () {
+      return [this.relayData.profile.name && this.relayData.profile.avatar && this.relayData.inbox.acceptancePrice].every(Boolean)
     }
   },
   async created () {

--- a/src/store/modules/contacts.js
+++ b/src/store/modules/contacts.js
@@ -1,6 +1,6 @@
 import { PublicKey } from 'bitcore-lib-cash'
 import { getRelayClient } from '../../utils/relay-client-factory'
-import { defaultUpdateInterval, defaultRelayData } from '../../utils/constants'
+import { defaultUpdateInterval, pendingRelayData } from '../../utils/constants'
 import KeyserverHandler from '../../keyserver/handler'
 import Vue from 'vue'
 import moment from 'moment'
@@ -93,7 +93,7 @@ export default {
   },
   actions: {
     addLoadingContact ({ commit }, { addr, pubKey }) {
-      let contact = { ...defaultRelayData, profile: { ...defaultRelayData.profile, pubKey } }
+      let contact = { ...pendingRelayData, profile: { ...pendingRelayData.profile, pubKey } }
       commit('addContact', { addr, contact })
     },
     deleteContact ({ commit }, addr) {

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -28,7 +28,7 @@ export const defaultRelayData = {
     pubKey: null
   },
   inbox: {
-    acceptancePrice: 10_000
+    acceptancePrice: defaultAcceptancePrice
   },
   notify: true
 }

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -22,6 +22,18 @@ export const defaultRelayUrl = '34.68.170.199:8531'
 export const relayUrlOptions = ['34.68.170.199:8531']
 export const defaultRelayData = {
   profile: {
+    name: '',
+    bio: null,
+    avatar: null,
+    pubKey: null
+  },
+  inbox: {
+    acceptancePrice: 10_000
+  },
+  notify: true
+}
+export const pendingRelayData = {
+  profile: {
     name: 'Loading...',
     bio: null,
     avatar: null,


### PR DESCRIPTION
**Motivation**
A few people had expressed problems when traversing the setup phase. The origin of these problems were due to lax validation on input fields.

**Changes**
- Add validation on Profile and Inbox data during setup.
- Split `defaultRelayData` in `pendingRelayData` and `defaultRelayData` - the former for a dummy contact profile used while adding contacts, the latter for an empty profile.