### PR TITLE
Ensure change addresses are also monitored

### DIFF
--- a/src/wallet/index.js
+++ b/src/wallet/index.js
@@ -217,7 +217,7 @@ export class Wallet {
   }
   async startListeners () {
     let ecl = this.electrumClient
-    const addresses = Object.keys(this.addresses)
+    const addresses = Object.keys(this.allAddresses)
     await ecl.events.on(
       'blockchain.scripthash.subscribe',
       async (result) => {


### PR DESCRIPTION
Due to an error in a previous commit, we did not spawn listeners with
our chosen electrum server for change addresses. This caused various
problems when sending large UTXOs as outbound transactions (e.g. stealth
payments).