### PR TITLE
Reset state of schema versions are different

### DIFF
--- a/src/store/modules/wallet.js
+++ b/src/store/modules/wallet.js
@@ -12,6 +12,10 @@ export function rehydrateWallet (wallet) {
     wallet.feePerByte = 2
   }
   wallet.xPrivKey = cashlib.HDPrivateKey.fromObject(wallet.xPrivKey)
+
+  if (!wallet.utxos) {
+    return
+  }
   for (const utxo of Object.values(wallet.utxos)) {
     if (utxo.type === 'p2pkh') {
       // Does not keep it's privKey with it because we like edge cases.


### PR DESCRIPTION
This commit causes chat messages and other actions to not cause disk
writes. The only thing that are stored are necessary items to restore
state from the relay server. We need to figure out how to only store
chat messages in bulk once they are loaded. Possibly some timer to
autosave in the future.