### PR TITLE
Remove chat state storage and remove blitting

### DIFF
--- a/src/components/dialogs/ProfileDialog.vue
+++ b/src/components/dialogs/ProfileDialog.vue
@@ -29,7 +29,7 @@
 </template>
 
 <script>
-import { mapActions, mapGetters } from 'vuex'
+import { mapMutations, mapGetters } from 'vuex'
 import Profile from '../Profile'
 import { constructProfileMetadata, constructPriceFilter } from '../../relay/constructors'
 import {
@@ -51,7 +51,7 @@ export default {
     ...mapGetters({
       getRelayData: 'myProfile/getRelayData'
     }),
-    ...mapActions({ setRelayData: 'myProfile/setRelayData' }),
+    ...mapMutations({ setRelayData: 'myProfile/setRelayData' }),
     async updateRelayData () {
       // Set profile
       let client = this.$relayClient

--- a/src/pages/Setup.vue
+++ b/src/pages/Setup.vue
@@ -244,7 +244,6 @@ export default {
   },
   methods: {
     ...mapActions({
-      setRelayData: 'myProfile/setRelayData',
       setRelayToken: 'relayClient/setToken',
       resetChats: 'chats/reset',
       darkMode: 'appearance/setDarkMode'
@@ -254,6 +253,7 @@ export default {
       getDarkMode: 'appearance/getDarkMode'
     }),
     ...mapMutations({
+      setRelayData: 'myProfile/setRelayData',
       resetWallet: 'wallet/reset',
       setXPrivKey: 'wallet/setXPrivKey',
       setSeedPhrase: 'wallet/setSeedPhrase',

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -23,6 +23,7 @@ const vuexLocal = new VuexPersistence({
   restoreState: (key, storage) => {
     const value = storage.getItem(key)
     let newState = parseState(value)
+    console.log('Restoring state', newState)
     if (newState.version !== STORE_SCHEMA_VERSION) {
       // Import everything else from the server again
       newState = {
@@ -42,7 +43,6 @@ const vuexLocal = new VuexPersistence({
     return newState
   },
   reducer (state) {
-    console.log('reducing state')
     return {
       wallet: {
         xPrivKey: path(['wallet', 'xPrivKey'], state),
@@ -56,16 +56,17 @@ const vuexLocal = new VuexPersistence({
     }
   },
   saveState (key, state, storage) {
-    console.log('saving state')
     storage.setItem(key, JSON.stringify(state))
   },
   filter: (mutation) => {
-    switch (mutation) {
+    switch (mutation.type) {
       case 'relayClient/setToken':
         return true
       case 'wallet/setXPrivKey':
         return true
       case 'wallet/setSeedPhrase':
+        return true
+      case 'myProfile/setRelayData':
         return true
     }
 

--- a/src/store/modules/my_profile.js
+++ b/src/store/modules/my_profile.js
@@ -13,27 +13,9 @@ export default {
     }
   },
   mutations: {
-    setProfile (state, profile) {
-      state.profile = profile
-    },
-    setInbox (state, inbox) {
-      state.inbox = inbox
-    },
     setRelayData (state, relayData) {
       state.profile = relayData.profile
       state.inbox = relayData.inbox
     }
-  },
-  actions: {
-    setProfile ({ commit }, profile) {
-      commit('setProfile', profile)
-    },
-    setInbox ({ commit }, inbox) {
-      commit('setInbox', inbox)
-    },
-    setRelayData ({ commit }, relayData) {
-      commit('setRelayData', relayData)
-    }
   }
-
 }


### PR DESCRIPTION
Currently, ever global state change causes a blit to disk of the full
chat state. This makes the chat app slow. This commit removes all the
chat state local storage. Instead, we always load from remote state.