### PR TITLE
Only save state every 10 seconds

### DIFF
--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -123,8 +123,8 @@ export default {
     // Setup everything at once. This are independent processes
     try {
       this.$relayClient.setUpWebsocket(this.$wallet.myAddressStr)
-      const lastReceived = this.lastReceived
-      await this.$relayClient.refresh({ lastReceived })
+      // const lastReceived = this.lastReceived
+      await this.$relayClient.refresh({ lastReceived: null })
       await this.$wallet.init()
     } catch (err) {
       console.error(err)

--- a/src/relay/constructors.js
+++ b/src/relay/constructors.js
@@ -23,6 +23,7 @@ export const constructStampTransaction = function (wallet, payloadDigest, destPu
     .deriveChild(transactionNumber)
     .deriveChild(outputNumber)
     .publicKey
+
   let stampOutput = new cashlib.Transaction.Output({
     script: cashlib.Script(new cashlib.Address(outpointPubKey)),
     satoshis: amount

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -4,7 +4,7 @@ import VuexPersistence from 'vuex-persist'
 import modules from './modules'
 import { rehydateChat } from './modules/chats'
 import { rehydrateWallet } from './modules/wallet'
-import { path } from 'ramda'
+import { path, map } from 'ramda'
 
 Vue.use(Vuex)
 
@@ -15,7 +15,9 @@ const parseState = (value) => {
     return (value || {})
   }
 }
-const STORE_SCHEMA_VERSION = 1
+const STORE_SCHEMA_VERSION = 2
+
+let lastSave = Date.now()
 
 const vuexLocal = new VuexPersistence({
   storage: window.localStorage,
@@ -34,10 +36,20 @@ const vuexLocal = new VuexPersistence({
         relayClient: {
           token: path(['relayClient', 'token'], newState)
         },
+        chats: {
+          data: map(addressData => {
+            return {
+              messages: {},
+              stampAmount: path(['stampAmount'], addressData),
+              lastRead: path(['lastRead'], addressData)
+            }
+          }, newState.chats.data)
+        },
         version: STORE_SCHEMA_VERSION,
         myProfile: newState.myProfile
       }
     }
+    console.log('new new state', newState)
     rehydateChat(newState.chats)
     rehydrateWallet(newState.wallet)
     return newState
@@ -51,26 +63,32 @@ const vuexLocal = new VuexPersistence({
       relayClient: {
         token: path(['relayClient', 'token'], state)
       },
+      chats: {
+        data: map(addressData => {
+          return ({
+            lastRead: addressData.lastRead,
+            // TODO: We need to save this remotely somewhere.
+            stampAmount: path(['stampAmount'], addressData),
+            messages: {}
+          })
+        },
+        state.chats.data)
+      },
       myProfile: state.myProfile,
       version: STORE_SCHEMA_VERSION
     }
   },
   saveState (key, state, storage) {
+    console.log('saving state', state.chats)
     storage.setItem(key, JSON.stringify(state))
   },
   filter: (mutation) => {
-    switch (mutation.type) {
-      case 'relayClient/setToken':
-        return true
-      case 'wallet/setXPrivKey':
-        return true
-      case 'wallet/setSeedPhrase':
-        return true
-      case 'myProfile/setRelayData':
-        return true
+    if (lastSave + 10000 >= Date.now()) {
+      return false
     }
+    lastSave = Date.now()
 
-    return false
+    return true
   }
 })
 

--- a/src/store/modules/chats.js
+++ b/src/store/modules/chats.js
@@ -97,7 +97,7 @@ export default {
       return sortedOrder
     },
     getStampAmount: (state) => (addr) => {
-      return state.data[addr].stampAmount
+      return state.data[addr].stampAmount || defaultStampAmount
     },
     getActiveChat (state) {
       return state.activeChatAddr
@@ -211,13 +211,13 @@ export default {
         Vue.set(state.data[addr].messages, index, newMsg)
       }
       state.messages[index] = newMsg
-      state.lastRead = newMsg.serverTime
-      state.data[addr].lastRead = newMsg.serverTime
+      state.data[addr].lastReceived = newMsg.serverTime
       const messageValue = stampPrice(newMsg.outpoints) + newMsg.items.reduce((totalValue, { amount = 0 }) => totalValue + amount, 0)
-      if (addr !== state.activeChatAddr) {
+      if (addr !== state.activeChatAddr && state.data[addr].lastRead < newMsg.serverTime) {
         state.data[addr].totalUnreadValue += messageValue
         state.data[addr].totalUnreadMessages += 1
       }
+      state.lastReceived = newMsg.serverTime
       state.data[addr].totalValue += messageValue
     },
     setStampAmount (state, { addr, stampAmount }) {


### PR DESCRIPTION
This commit adjusts the save frequency to every 10 seconds. It also
reduces state to a bear minimum of items. Restore will always download
all messages from the remote server at this point. In the future we
shoudl be more intellignet about what data we actually pull on restore.
However, right now we want to ensure that people loading the client
will have a good experience given that they may need to migrate their
schema.