### PR TITLE
Use a random electrum server for the address listeners

### DIFF
--- a/src/boot/setup-apis.js
+++ b/src/boot/setup-apis.js
@@ -1,6 +1,6 @@
 
 import { Client as ElectrumClient } from 'electrum-cash'
-import { electrumPingInterval, electrumURL, electrumPort, defaultRelayUrl } from '../utils/constants'
+import { electrumPingInterval, electrumServers, defaultRelayUrl } from '../utils/constants'
 import { Wallet } from '../wallet'
 import { getRelayClient } from '../utils/relay-client-factory'
 
@@ -91,6 +91,8 @@ function getWalletClient ({ store }) {
 }
 
 export default async ({ store, Vue }) => {
+  const { electrumURL, electrumPort } = electrumServers[Math.floor(Math.random() * electrumServers.length)]
+  console.log('Using electrum server:', electrumURL, electrumPort)
   const { client: electrumClient, observables: electrumObservables } = await getElectrumClient({ host: electrumURL, port: electrumPort })
   // TODO: WE should probably rename this file to something more specific
   // as its instantiating the wallet now also.

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -2,8 +2,36 @@ export const minSplitter = 20
 export const maxSplitter = 75
 
 // Electrum constants
-export const electrumURL = 'testnet.bitcoincash.network'
-export const electrumPort = 60002
+export const electrumServers = [
+  {
+    electrumURL: 'testnet.bitcoincash.network',
+    electrumPort: 60_002
+  },
+  {
+    electrumURL: 'electroncash.de',
+    electrumPort: 50_004
+  },
+  {
+    electrumURL: 'fulcrum-testnet.bchjs.cash',
+    electrumPort: 50_002
+  },
+  {
+    electrumURL: 'testnet.imaginary.cash',
+    electrumPort: 50_002
+  },
+  {
+    electrumURL: 'bch0.kister.net',
+    electrumPort: 51_002
+  },
+  {
+    electrumURL: 'blackie.c3-soft.com',
+    electrumPort: 60_002
+  },
+  {
+    electrumURL: 'cash-testnet.theblains.org',
+    electrumPort: 50_002
+  }
+]
 export const electrumPingInterval = 10_000
 
 // Wallet constants


### PR DESCRIPTION
Currently, we've been using one wallet server. Due to some of the
earlier code around listeners, we got banned. This commit uses a
simply random selection of the main testnet electrum servers to
connect to and set listeners on.