### PR TITLE
Removing dead server

### DIFF
--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -26,10 +26,6 @@ export const electrumServers = [
   {
     electrumURL: 'blackie.c3-soft.com',
     electrumPort: 60_002
-  },
-  {
-    electrumURL: 'cash-testnet.theblains.org',
-    electrumPort: 50_002
   }
 ]
 export const electrumPingInterval = 10_000


### PR DESCRIPTION
On first run, `cash-testnet.theblains.org` was returning an http 404.  This was causing the application to throw inside the "wallet setup" flow, keeping the "next" button disabled.  I could only proceed by removing the bad server from the list and forcing a reload.