### PR TITLE
Update LICENSE and Github pull_request_template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,5 @@
+Thank you for contributing to Stamp! We really appreciate it. Our mission is to spread P2P electronic cash to the world. 
+
+Please note, due to common industry practices of re-packaging open source software by for-profit business, we have an unusual software license. This license provides open access to the software source code, and reproduction thereof by community (non-commercial) projects, but excludes use of reproductions, and repackaging, by other for-profit organizations.
+
+As such, by opening this pull request you acknowledge that you are providing the owners of this project an unlimited license to use and reproduce your contribution.

--- a/LICENSE
+++ b/LICENSE
@@ -1,13 +1,16 @@
-MIT License
+Stamp License
 
-Copyright (c) 2019 cash:web
+Copyright (c) 2019 Shammah Chancellor
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+of this software and associated documentation files (the "Software"), to modify
+and run it for personal use only.
+
+The modified software may be redistributed privately among personal contacts in
+compiled form. No public distribution of packaged version of this is permitted.
+The modified software source code may be redistributed publicly.
+
+For-profit reproductions of this software are EXPLICITLY forbidden.
 
 The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.


### PR DESCRIPTION
It's been a frequent practice that various companies, are whitebox-
relabling open source projects within the open source ecosystem. This
is a large hinderance to the professional maintenance of software
projects. As such, we are changing from an MIT license, to something
which permits the free distribution, and modification of source code
*only*.

We welcome competition within the Stamp ecosystem, and the backend
services and protocol are free and open. However, we wish to force
companies to participate in *this* project, by relicensing or directly
contributing -- rather than producing poorly maintained forks.

My hope is that this project will able to self-sustain through a
commercial offering. Having this project copied and rebranded by for-
profit companies