### PR TITLE
Ensure we choose a new electrum server on reconnect

### DIFF
--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -2,6 +2,7 @@ import store from '../store/index'
 
 async function redirectIfNoProfile (to, from, next) {
   let name = await store.getters['myProfile/getProfile'].name
+  console.log('name', name)
   if (name !== null) {
     next()
   } else {


### PR DESCRIPTION
A fair number of electrum servers seem to have bad uptime. This commit
addresses this by trying a new electrum server upon reconnect. Ideally,
we use multiple servers so as to not give away too much information
about which addresses we are using. However, this should work just to
ensure we are able to remain connected to the electrum servers