### PR TITLE
Move drawer toggles to a toolbar in the chatlist area

### DIFF
--- a/src/components/chat/ChatList.vue
+++ b/src/components/chat/ChatList.vue
@@ -1,5 +1,5 @@
 <template>
-  <q-list>
+  <div class="column full-height">
     <!-- Wallet dialog -->
     <q-dialog v-model="walletOpen">
       <wallet-dialog />
@@ -10,58 +10,50 @@
       <relay-connect-dialog />
     </q-dialog>
 
-    <q-item
-      clickable
-      v-ripple
-    >
-      <q-item-section @click="walletOpen=true">
-        <q-item-label>Balance</q-item-label>
-        <q-item-label caption>{{ getBalance }}</q-item-label>
-      </q-item-section>
-      <q-item-section
-        v-if="!walletConnected"
-        side
-      >
-        <q-btn
-          icon='account_balance_wallet'
-          flat
-          round
-          color="red"
+    <!-- New contact dialog -->
+    <q-dialog v-model="newContactOpen">
+      <new-contact-dialog />
+    </q-dialog>
+
+    <q-toolbar>
+      <q-space />
+      <q-btn class="q-px-sm" flat dense @click="toggleMyDrawerOpen" icon="menu" />
+      <q-btn class="q-px-sm" flat dense @click="newContactOpen = true" icon="add" />
+      <q-btn class="q-px-sm" flat dense @click="toggleContactDrawerOpen" icon="person" />
+    </q-toolbar>
+    <q-scroll-area class="q-px-none col">
+      <q-list>
+        <q-separator />
+        <chat-list-item
+          v-for="(contact) in getSortedChatOrder"
+          :key="contact.address"
+          :chatAddr="contact.address"
+          :valueUnread="formatBalance(contact.totalUnreadValue)"
+          :numUnread="contact.totalUnreadMessages"
         />
-      </q-item-section>
-      <q-item-section
-        v-if="!relayConnected"
-        side
-        clickable
-        @click="relayConnectOpen=true"
-      >
-        <q-btn
-          icon='email'
-          flat
-          round
-          color="red"
-        />
-      </q-item-section>
-    </q-item>
-    <q-separator />
-    <q-scroll-area
-      class="q-px-none row"
-      :style="`min-height:calc(100% - 51px); height: calc(100% - 51px);`"
-    >
-      <chat-list-item
-        v-for="(contact) in getSortedChatOrder"
-        :key="contact.address"
-        :chatAddr="contact.address"
-        :valueUnread="formatBalance(contact.totalUnreadValue)"
-        :numUnread="contact.totalUnreadMessages"
-      />
-      <q-item v-if="getSortedChatOrder.length === 0">
+        <q-item v-if="getSortedChatOrder.length === 0">
+          <q-item-section>
+            <q-item-label>Add contacts from the drawer above...</q-item-label>
+          </q-item-section>
+        </q-item>
+      </q-list>
+    </q-scroll-area>
+    <q-item-list>
+      <q-separator />
+      <q-item clickable @click="walletOpen=true">
         <q-item-section>
-          <q-item-label>Add contacts from the drawer above...</q-item-label>
+          <q-item-label>Balance</q-item-label>
+          <q-item-label caption>{{ getBalance }}</q-item-label>
+        </q-item-section>
+        <q-item-section v-if="!walletConnected" side>
+          <q-btn icon="account_balance_wallet" flat round color="red" />
+        </q-item-section>
+        <q-item-section v-if="!relayConnected" side clickable @click="relayConnectOpen=true">
+          <q-btn icon="email" flat round color="red" />
         </q-item-section>
       </q-item>
-    </q-scroll-area>
-  </q-list>
+    </q-item-list>
+  </div>
 </template>
 
 <script>
@@ -69,6 +61,7 @@ import ChatListItem from './ChatListItem.vue'
 import { mapGetters } from 'vuex'
 import { formatBalance } from '../../utils/formatting'
 import WalletDialog from '../dialogs/WalletDialog.vue'
+import NewContactDialog from '../dialogs/NewContactDialog.vue'
 import RelayConnectDialog from '../dialogs/RelayConnectDialog.vue'
 
 export default {
@@ -76,12 +69,14 @@ export default {
   components: {
     ChatListItem,
     WalletDialog,
-    RelayConnectDialog
+    RelayConnectDialog,
+    NewContactDialog
   },
   data () {
     return {
       walletOpen: false,
-      relayConnectOpen: false
+      relayConnectOpen: false,
+      newContactOpen: false
     }
   },
   methods: {
@@ -90,6 +85,12 @@ export default {
         return balance
       }
       return formatBalance(balance)
+    },
+    toggleMyDrawerOpen () {
+      this.$emit('toggleMyDrawerOpen')
+    },
+    toggleContactDrawerOpen () {
+      this.$emit('toggleContactDrawerOpen')
     }
   },
   computed: {

--- a/src/components/chat/ChatListItem.vue
+++ b/src/components/chat/ChatListItem.vue
@@ -3,7 +3,6 @@
     :active="isActive"
     active-class="bg-blue-3 text-black"
     clickable
-    v-ripple
     @click="setActiveChat(chatAddr)"
   >
     <q-item-section avatar>

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -31,7 +31,7 @@
           unit="px"
         >
           <template v-slot:before>
-            <chat-list class="full-height" />
+            <chat-list class="full-height" @toggleContactDrawerOpen="toggleContactDrawerOpen" @toggleMyDrawerOpen="toggleMyDrawerOpen" />
           </template>
 
           <template v-slot:after>
@@ -43,8 +43,6 @@
               :messages="item.messages"
               :active="activeChatAddr === index"
               :style="`height: inherit; min-height: inherit;`"
-              @toggleContactDrawerOpen="toggleContactDrawerOpen"
-              @toggleMyDrawerOpen="toggleMyDrawerOpen"
             />
           </template>
         </q-splitter>

--- a/src/pages/Chat.vue
+++ b/src/pages/Chat.vue
@@ -7,21 +7,11 @@
     </q-dialog>
 
     <q-header bordered>
-      <q-toolbar class="q-pl-none">
-        <q-btn class="q-px-sm bg-primary" flat dense @click="toggleMyDrawerOpen" icon="menu" />
+      <q-toolbar class="q-pl-sm">
         <q-avatar rounded>
           <img :src="contactProfile.avatar" />
         </q-avatar>
         <q-toolbar-title class="h6">{{contactProfile.name}}</q-toolbar-title>
-        <q-space />
-        <q-btn
-          class="q-px-sm"
-          flat
-          dense
-          color="bg-primary"
-          @click="toggleContactDrawerOpen"
-          icon="person"
-        />
       </q-toolbar>
     </q-header>
     <q-page-container>
@@ -148,12 +138,6 @@ export default {
         this.replyDigest = null
         this.$nextTick(() => this.$refs.chatInput.$el.focus())
       }
-    },
-    toggleMyDrawerOpen () {
-      this.$emit('toggleMyDrawerOpen')
-    },
-    toggleContactDrawerOpen () {
-      this.$emit('toggleContactDrawerOpen')
     },
     scrollBottom () {
       const scrollArea = this.$refs.chatScroll


### PR DESCRIPTION
As per title. Fixes up formatting of the various action buttons, and
moves them to the chatlist. Additionally, we fix the use of `q-list`
since the items were being interleaved with the `q-scroll-area` and
should not have been.