### PR TITLE
Add stamp amount settings to chat input box

### DIFF
--- a/src/components/chat/ChatInput.vue
+++ b/src/components/chat/ChatInput.vue
@@ -34,6 +34,7 @@
         @click="sendMessage"
         :color="`${$q.dark.isActive ? 'light' : 'dark'}`"
       />
+      <q-input dense outlined style="width: 125px" label="Stamp" suffix="sats" v-bind:value="stampAmount" @input="stampAmountChanged" input-class="text-right" />
     </q-toolbar>
   </div>
 </template>
@@ -49,7 +50,8 @@ export default {
     event: 'input'
   },
   props: {
-    message: String
+    message: String,
+    stampAmount: Number
   },
   methods: {
     focus () {
@@ -69,6 +71,9 @@ export default {
     },
     sendFileClicked () {
       this.$emit('sendFileClicked')
+    },
+    stampAmountChanged (value) {
+      this.$emit('stampAmountChanged', value)
     }
   }
 }

--- a/src/pages/Chat.vue
+++ b/src/pages/Chat.vue
@@ -60,9 +60,11 @@
       <chat-input
         ref="chatInput"
         v-model="message"
+        v-bind:stampAmount="stampAmount"
         @sendMessage="sendMessage"
         @sendFileClicked="sendFileOpen = true"
         @sendMoneyClicked="sendMoneyOpen = true"
+        @stampAmountChanged="stampAmountChanged"
       />
     </q-footer>
   </q-layout>
@@ -70,7 +72,7 @@
 
 <script>
 import moment from 'moment'
-import { mapGetters } from 'vuex'
+import { mapGetters, mapActions } from 'vuex'
 import { dom } from 'quasar'
 const { height } = dom
 
@@ -129,6 +131,9 @@ export default {
       getAcceptancePrice: 'contacts/getAcceptancePrice',
       getStampAmount: 'chats/getStampAmount'
     }),
+    ...mapActions({
+      setStampAmount: 'chats/setStampAmount'
+    }),
     sendMessage (message) {
       const stampAmount = this.getStampAmount()(this.address)
       const acceptancePrice = this.getAcceptancePrice()(this.address)
@@ -146,6 +151,10 @@ export default {
         this.replyDigest = null
         this.$nextTick(() => this.$refs.chatInput.$el.focus())
       }
+    },
+    stampAmountChanged (stampAmount) {
+      console.log(this.address, stampAmount)
+      this.setStampAmount({ addr: this.address, stampAmount })
     },
     scrollBottom () {
       const scrollArea = this.$refs.chatScroll
@@ -198,6 +207,9 @@ export default {
       getMessage: 'chats/getMessage',
       getProfile: 'myProfile/getProfile'
     }),
+    stampAmount () {
+      return Number(this.getStampAmount()(this.address))
+    },
     replyItem () {
       if (!this.replyDigest) {
         return null


### PR DESCRIPTION
In order to ensure that users are seeing the stamp amount the are using,
we're adding it to the chat input box. It can also be set from there.

<img width="286" alt="image" src="https://user-images.githubusercontent.com/213740/81492449-9a2c8480-924c-11ea-8558-3c597357aeab.png">