### PR TITLE
Hide contract drawer now that no items are necssary on it

### DIFF
--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -6,7 +6,6 @@
     <q-drawer
       v-model="myDrawerOpen"
       v-if="loaded"
-      show-if-above
       overlay
       bordered
       behavior="mobile"
@@ -15,10 +14,9 @@
     >
       <settings-panel />
     </q-drawer>
-    <q-drawer v-model="contactDrawerOpen" show-if-above side="right" :width="300" :breakpoint="400" bordered>
+    <q-drawer v-model="contactDrawerOpen" v-if="loaded" side="right" :width="300" :breakpoint="400" bordered>
       <contact-panel
         v-if="activeChatAddr !== null"
-        v-model="contactDrawerOpen"
         :address="activeChatAddr"
         :contact="getContact(activeChatAddr)"
       />
@@ -71,7 +69,7 @@ export default {
       splitterRatio: 200,
       loaded: false,
       myDrawerOpen: false,
-      contactDrawerOpen: true
+      contactDrawerOpen: false
     }
   },
   methods: {


### PR DESCRIPTION
We have moved most of the necessary functionality in the contact drawer
to other areas on the screen for relatively small amounts of space. As,
such we don't need to continue showing it constantly by default. This
commit changes the default behavior