### PR TITLE
Remove excess action `deleteMessage` which does not need to dispatch

### DIFF
--- a/src/components/context_menus/ChatMessageMenu.vue
+++ b/src/components/context_menus/ChatMessageMenu.vue
@@ -59,13 +59,13 @@
 </template>
 
 <script>
-import { mapActions } from 'vuex'
+import { mapMutations } from 'vuex'
 import { copyToClipboard } from 'quasar'
 
 export default {
   props: ['address', 'id', 'message'],
   methods: {
-    ...mapActions({
+    ...mapMutations({
       deleteMessage: 'chats/deleteMessage'
     }),
     sendMessage (...args) {

--- a/src/components/dialogs/DeleteMessageDialog.vue
+++ b/src/components/dialogs/DeleteMessageDialog.vue
@@ -28,11 +28,11 @@
 </template>
 
 <script>
-import { mapActions } from 'vuex'
+import { mapMutations } from 'vuex'
 export default {
   props: ['address', 'index'],
   methods: {
-    ...mapActions({
+    ...mapMutations({
       deleteMessage: 'chats/deleteMessage'
     }),
     async deleteMessageBoth () {

--- a/src/store/modules/chats.js
+++ b/src/store/modules/chats.js
@@ -225,9 +225,6 @@ export default {
     }
   },
   actions: {
-    deleteMessage ({ commit }, { addr, id }) {
-      commit('deleteMessage', { addr, id })
-    },
     reset ({ commit }) {
       commit('reset')
     },


### PR DESCRIPTION
Use the `deleteMessage` mutation directly. There is no reason to do
an action within this context.
