### PR TITLE
Use arrays for chat message handling

### DIFF
--- a/src/components/chat/ChatMessageSection.vue
+++ b/src/components/chat/ChatMessageSection.vue
@@ -10,7 +10,7 @@
         <chat-message-section
           class="q-pa-sm row-auto "
           style="border-radius: 5px;"
-          :items="getMessage(address, item.payloadDigest).items"
+          :items="getMessage(item.payloadDigest).items"
           :address="address"
         />
       </div>
@@ -54,7 +54,7 @@ export default {
   },
   methods: {
     ...mapGetters({
-      getMessageVuex: 'chats/getMessage'
+      getMessageByPayloadVuex: 'chats/getMessageByPayload'
     }),
     formatSats (value) {
       return formatBalance(Number(value))
@@ -63,8 +63,8 @@ export default {
       this.image = image
       this.imageDialog = true
     },
-    getMessage (address, payloadDigest) {
-      const message = this.getMessageVuex()(address, payloadDigest)
+    getMessage (payloadDigest) {
+      const message = this.getMessageByPayloadVuex()(payloadDigest)
       return message || { items: [] }
     }
   }

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -31,7 +31,7 @@
 
           <template v-slot:after>
             <chat
-              v-for="(item, index) in data"
+              v-for="(item, index) in chats"
               v-show="activeChatAddr === index"
               :key="index"
               :address="index"
@@ -91,7 +91,7 @@ export default {
     }
   },
   computed: {
-    ...mapState('chats', ['data', 'activeChatAddr']),
+    ...mapState('chats', ['chats', 'activeChatAddr']),
     ...mapGetters({
       getContact: 'contacts/getContact',
       lastReceived: 'chats/getLastReceived'

--- a/src/pages/Chat.vue
+++ b/src/pages/Chat.vue
@@ -28,13 +28,13 @@
             index="NA"
             key="NA"
           />
-          <template v-for="(chatMessage, index) in messages">
+          <template v-for="chatMessage in messages">
             <chat-message
-              :key="index"
+              :key="chatMessage.payloadDigest"
               :address="address"
               :message="chatMessage"
               :contact="getContact(chatMessage.outbound)"
-              :index="index"
+              :index="chatMessage.payloadDigest"
               :now="now"
               @replyClicked="({ address, index }) => setReply(index)"
             />
@@ -90,8 +90,8 @@ export default {
   props: {
     address: String,
     messages: {
-      type: Object,
-      default: () => {}
+      type: Array,
+      default: () => []
     },
     active: {
       type: Boolean,
@@ -204,7 +204,7 @@ export default {
   computed: {
     ...mapGetters({
       getContactVuex: 'contacts/getContact',
-      getMessage: 'chats/getMessage',
+      getMessageByPayload: 'chats/getMessageByPayload',
       getProfile: 'myProfile/getProfile'
     }),
     stampAmount () {
@@ -214,7 +214,7 @@ export default {
       if (!this.replyDigest) {
         return null
       }
-      const msg = this.getMessage(this.address, this.replyDigest)
+      const msg = this.getMessageByPayload(this.replyDigest)
       if (!msg) {
         return null
       }

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -37,13 +37,13 @@ const vuexLocal = new VuexPersistence({
           token: path(['relayClient', 'token'], newState)
         },
         chats: {
-          data: map(addressData => {
+          chats: map(addressData => {
             return {
-              messages: {},
+              messages: [],
               stampAmount: path(['stampAmount'], addressData),
               lastRead: path(['lastRead'], addressData)
             }
-          }, pathOr({}, ['chats', 'data'], newState))
+          }, pathOr({}, ['chats', 'chats'], newState))
         },
         version: STORE_SCHEMA_VERSION,
         myProfile: newState.myProfile
@@ -64,7 +64,7 @@ const vuexLocal = new VuexPersistence({
         token: path(['relayClient', 'token'], state)
       },
       chats: {
-        data: map(addressData => {
+        chats: map(addressData => {
           return ({
             lastRead: addressData.lastRead,
             // TODO: We need to save this remotely somewhere.


### PR DESCRIPTION
Currently, we're using a hashmap for messages per contact. However,
these should be unordered. It's unclear how these are showing up in the
correct order (beyond the fact that they are added sequentially). In the
future this may change for efficiency purposes, additionally, we want to
be able to omit some parts of `ChatMessage` displays -- as well as add
in separators in some cases. Thus, this commit switches to using a
normal ordered array for each chat's messages.
