### PR TITLE
Add type annotations to `router.ts`

### DIFF
--- a/src/router/routes.ts
+++ b/src/router/routes.ts
@@ -1,9 +1,9 @@
-import { RouteConfig } from 'vue-router'
+import { RouteConfig, Route } from 'vue-router'
 import store from '../store/index'
 
-async function redirectIfNoProfile (to, from, next) {
-  const name = await store.getters['myProfile/getProfile'].name
-  if (name !== null) {
+function redirectIfNoProfile (to: Route, from: Route, next: (route?: string) => void) {
+  const name = store.getters['myProfile/getProfile'].name
+  if (name) {
     next()
   } else {
     next('/setup')


### PR DESCRIPTION
During the quasar upgrade, we tested using typescript on the router.
However, while this worked in dev mode, eslint complained during build
that we were lacking type annotations. This commit adds them in.
