### PR TITLE
Switch back to quasar builder from quasar packager

### DIFF
--- a/quasar.conf.js
+++ b/quasar.conf.js
@@ -179,7 +179,7 @@ module.exports = configure(function (ctx) {
 
     // Full list of options: https://quasar.dev/quasar-cli/developing-electron-apps/configuring-electron
     electron: {
-      bundler: 'packager', // 'packager' or 'builder'
+      bundler: 'builder', // 'packager' or 'builder'
 
       packager: {
         // https://github.com/electron-userland/electron-packager/blob/master/docs/api.md#options


### PR DESCRIPTION
During the quasar upgrade, we accidentally changed our build system to
be quasar packager. Unfortunately, packager does not support everything
we need, and seems to error out on MacOS.
