### PR TITLE
Change to a generic error notification "toast"

### DIFF
--- a/src/components/dialogs/ProfileDialog.vue
+++ b/src/components/dialogs/ProfileDialog.vue
@@ -32,10 +32,7 @@
 import { mapMutations, mapGetters } from 'vuex'
 import Profile from '../Profile'
 import { constructProfileMetadata, constructPriceFilter } from '../../relay/constructors'
-import {
-  relayDisconnectedNotify,
-  profileTooLargeNotify
-} from '../../utils/notifications'
+import { errorNotify } from '../../utils/notifications'
 
 export default {
   props: ['currentProfile'],
@@ -75,10 +72,10 @@ export default {
       } catch (err) {
         console.error(err)
         if (err.response.status === 413) {
-          profileTooLargeNotify()
+          errorNotify('Profile avatar is too large, select a smaller image.')
           throw err
         }
-        relayDisconnectedNotify()
+        errorNotify(new Error('Unable to contact relay server.'))
         throw err
       }
 

--- a/src/components/dialogs/SendAddressDialog.vue
+++ b/src/components/dialogs/SendAddressDialog.vue
@@ -45,7 +45,7 @@
 </template>
 
 <script>
-import { sentTransactionNotify, sentTransactionFailureNotify } from '../../utils/notifications'
+import { sentTransactionNotify, errorNotify } from '../../utils/notifications'
 
 const cashlib = require('bitcore-lib-cash')
 
@@ -86,8 +86,8 @@ export default {
         await electrumHandler.request('blockchain.transaction.broadcast', txHex)
         sentTransactionNotify(transaction)
       } catch (err) {
-        sentTransactionFailureNotify(transaction)
         console.error(err)
+        errorNotify(new Error('Failed to send transaction')
         // Unfreeze UTXOs if stealth tx broadcast fails
         usedIDs.forEach(id => {
           this.$wallet.unfreezeUTXO(id)

--- a/src/utils/notifications.js
+++ b/src/utils/notifications.js
@@ -12,37 +12,17 @@ const negativeNotify = function (text) {
   })
 }
 
-export const chainTooLongNotify = function () {
-  negativeNotify('Transaction chain too long or relay fee too low.')
-}
-
-export const insuffientFundsNotify = function () {
-  negativeNotify('Insufficent funds.')
-}
-
-export const walletDisconnectedNotify = function () {
-  negativeNotify('Unable to contact wallet server.')
-}
-
-export const keyserverDisconnectedNotify = function () {
-  negativeNotify('Unable to contact keyserver.')
-}
-
-export const relayDisconnectedNotify = function () {
-  negativeNotify('Unable to contact relay server.')
-}
-
-export const paymentFailureNotify = function () {
-  negativeNotify('Payment was rejected.')
-}
-
-export const profileTooLargeNotify = function () {
-  negativeNotify('Profile is too large.')
+export const errorNotify = function (err) {
+  console.error(err)
+  if (err.response) {
+    console.error(err.response)
+  }
+  negativeNotify(err.message)
 }
 
 // Info notifications
 
-const infoNotify = function (text) {
+export const infoNotify = function (text) {
   Notify.create({
     message: '<div class="text-center"> ' + text + ' </div>',
     html: true,
@@ -62,7 +42,7 @@ export const seedCopiedNotify = function () {
   infoNotify('Seed phrase copied to clipboard.')
 }
 
-export const sentTransactionNotify = function (tx) {
+export const sentTransactionNotify = function () {
   Notify.create({
     message: '<div class="text-center"> Sent transaction </div>',
     html: true,
@@ -72,20 +52,6 @@ export const sentTransactionNotify = function (tx) {
     ]
   })
 }
-
-export const sentTransactionFailureNotify = function (tx) {
-  // TODO: Display transaction
-  console.log('failure', tx)
-  Notify.create({
-    message: '<div class="text-center"> Failed to send transaction </div>',
-    html: true,
-    color: 'negative',
-    actions: [
-      { label: 'View', color: 'secondary', handler: () => { /* ... */ } }
-    ]
-  })
-}
-
 export const desktopNotify = function (title, body, icon, callback) {
   const notify = new window.Notification(title, {
     title,


### PR DESCRIPTION
This commit switches from using a specific error notification function
for each error type, to a generic one. The generic notification should
specialize internally for each error type we can receive in the future.
This allows for moving everything up into the body of one try/catch for
errors while still reporting specific messages.
