### PR TITLE
Ensure icons are bundled with the app on MacOS

### DIFF
--- a/quasar.conf.js
+++ b/quasar.conf.js
@@ -197,7 +197,11 @@ module.exports = configure(function (ctx) {
       builder: {
         // https://www.electron.build/configuration/configuration
 
-        appId: 'stamp'
+        appId: 'stamp',
+        extraFiles: [
+          { from: 'src-electron/icons', to: 'resources/icons' }
+        ],
+        publish: []
       },
 
       // More info: https://quasar.dev/quasar-cli/developing-electron-apps/node-integration


### PR DESCRIPTION
This reverts a previous change when we bumped the quasar version
that stopped the tray icon from being bundled on MacOS X.
