### PR TITLE
Basic text coloring

### DIFF
--- a/src/components/chat/ChatMessage.vue
+++ b/src/components/chat/ChatMessage.vue
@@ -31,8 +31,7 @@
     <div class="row">
       <div class="col">
         <!-- TODO: Assign random color based on seed from name -->
-        <div class="col text-weight-bold" style="border-bottom: 1px solid grey;"><div :style="nameColor"> {{contact.name}} </div></div>
-        <div class="col text-weight-bold" style="border-bottom: 1px solid grey;" v-if="showHeader">{{contact.name}}</div>
+        <div class="col text-weight-bold" style="border-bottom: 1px solid grey;" v-if="showHeader"><div :style="nameColor"> {{contact.name}} </div></div>
         <chat-message-section :key="index" :items="message.items" :address="address" />
       </div>
       <div class="col-auto" style="min-width: 100px">

--- a/src/components/chat/ChatMessage.vue
+++ b/src/components/chat/ChatMessage.vue
@@ -31,6 +31,7 @@
     <div class="row">
       <div class="col">
         <!-- TODO: Assign random color based on seed from name -->
+        <div class="col text-weight-bold" style="border-bottom: 1px solid grey;"><div :style="nameColor"> {{contact.name}} </div></div>
         <div class="col text-weight-bold" style="border-bottom: 1px solid grey;" v-if="showHeader">{{contact.name}}</div>
         <chat-message-section :key="index" :items="message.items" :address="address" />
       </div>
@@ -69,6 +70,7 @@ export default {
     }
   },
   props: {
+    nameColor: String,
     address: String,
     message: Object,
     contact: Object,

--- a/src/pages/Chat.vue
+++ b/src/pages/Chat.vue
@@ -37,6 +37,7 @@
               :contact="getContact(chatMessage.outbound)"
               :index="chatMessage.payloadDigest"
               :now="now"
+              :nameColor="chatMessage.outbound ? '': nameColor"
               @replyClicked="({ address, index }) => setReply(index)"
             />
           </template>
@@ -84,6 +85,8 @@ import ChatMessageReply from '../components/chat/ChatMessageReply.vue'
 import SendBitcoinDialog from '../components/dialogs/SendBitcoinDialog.vue'
 import { donationMessage } from '../utils/constants'
 import { insufficientStampNotify } from '../utils/notifications'
+import { addressColor } from '../utils/formatting'
+import { Address } from 'bitcore-lib-cash'
 
 const scrollDuration = 0
 
@@ -209,6 +212,16 @@ export default {
     }
   },
   computed: {
+    nameColor () {
+      // Get color
+      if (this.address) {
+        const addr = new Address(this.address)
+        const { hue, saturation } = addressColor(addr)
+        return `color: hsl(${hue}, ${saturation * 100}%, 60%);`
+      } else {
+        return ''
+      }
+    },
     ...mapGetters({
       getContactVuex: 'contacts/getContact',
       getMessageByPayload: 'chats/getMessageByPayload',

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -75,3 +75,7 @@ export const notificationTimeout = 4000
 
 // Contact defaults
 export const defaultUpdateInterval = 60 * 10 * 1_000
+
+// Formatting constants
+// TODO: Generate this
+export const colorSalt = Buffer.from('salt')

--- a/src/utils/formatting.js
+++ b/src/utils/formatting.js
@@ -1,4 +1,5 @@
 const cashlib = require('bitcore-lib-cash')
+import { colorSalt } from './constants'
 
 export const formatBalance = function (balance) {
   if (balance < 1_000) {
@@ -20,4 +21,17 @@ export const toElectrumScriptHash = function (addr) {
   const digest = cashlib.crypto.Hash.sha256(scriptHashRaw)
   const digestHexReversed = digest.reverse().toString('hex')
   return digestHexReversed
+}
+
+export const addressColor = function (addr) {
+  const rawAddress = addr.toBuffer()
+
+  // Add salt
+  const saltedAddress = Buffer.concat([rawAddress, colorSalt])
+
+  const hashbuf = cashlib.crypto.Hash.sha256(saltedAddress)
+  const hue = hashbuf[0]
+  const saturation = hashbuf[1] / 255
+
+  return { hue, saturation }
 }


### PR DESCRIPTION
**Motivation**
Suppose a malicious actor copied someones profile and messages you - it would be tough to distinguish the original from the fake purely based on the difference in the address. Especially when one can grind on addresses to achieve similarity.

In order to help users distinguish between the friend and the malicious actor we introduce a colour scheme whereby a colour is selected using `H(address || salt)`.

**Implementation**
The current implementation should work as an basis for future iteration. We currently pick the hue and saturation from the first two bytes of the digest and fix the lightness to achieve a colour from HSL. The lightness is fixed to avoid very bright or very dark colors which make hurt accessibility.

The salt is currently hardcoded into the `constants.js` but in future should be deterministically generated from the identity private key or randomly generated at setup then stored.