### PR TITLE
Formatted text

### DIFF
--- a/src/components/Settings.vue
+++ b/src/components/Settings.vue
@@ -118,10 +118,6 @@ export default {
       // console.log(this.currencyFormat)
       this.$emit('input', this.constructSettings)
     }
-  },
-  created () {
-    console.log(this.currencyFormat)
-    console.log(this.currentFormatOptions)
   }
 }
 </script>

--- a/src/components/Settings.vue
+++ b/src/components/Settings.vue
@@ -45,10 +45,20 @@
           </div>
           </q-tab-panel>
           <q-tab-panel name="appearance">
-            <div class="row">
+            <div class="col">
               <q-toggle
+                class="row"
                 :label="`Dark Mode`"
                 v-model="darkMode"
+              />
+              <q-select
+                class="row"
+                filled
+                v-model="currencyFormat"
+                :options="currentFormatOptions"
+                label="Current Format"
+                emit-value
+                map-options
               />
           </div>
           </q-tab-panel>
@@ -62,14 +72,26 @@
 export default {
   props: {
     value: {
-      type: Object
+      type: Object,
+      required: true
     }
   },
   data () {
     return {
       tab: 'networking',
       darkMode: this.value.appearance.darkMode,
-      updateInterval: this.value.networking.updateInterval
+      currencyFormat: this.value.appearance.currencyFormat,
+      updateInterval: this.value.networking.updateInterval,
+      currentFormatOptions: [
+        {
+          label: 'Bitcoin',
+          value: { type: 'sats' }
+        },
+        {
+          label: 'USD',
+          value: { type: 'fiat', conversion: 0.000002 }
+        }
+      ]
     }
   },
   computed: {
@@ -79,7 +101,8 @@ export default {
           updateInterval: this.updateInterval
         },
         appearance: {
-          darkMode: this.darkMode
+          darkMode: this.darkMode,
+          currencyFormat: this.currencyFormat
         }
       }
     }
@@ -90,7 +113,15 @@ export default {
     },
     darkMode () {
       this.$emit('input', this.constructSettings)
+    },
+    currencyFormat () {
+      // console.log(this.currencyFormat)
+      this.$emit('input', this.constructSettings)
     }
+  },
+  created () {
+    console.log(this.currencyFormat)
+    console.log(this.currentFormatOptions)
   }
 }
 </script>

--- a/src/components/chat/ChatList.vue
+++ b/src/components/chat/ChatList.vue
@@ -84,7 +84,7 @@ export default {
       if (!balance) {
         return balance
       }
-      return formatBalance(balance)
+      return formatBalance(balance, this.getCurrencyFormat)
     },
     toggleMyDrawerOpen () {
       this.$emit('toggleMyDrawerOpen')
@@ -96,7 +96,8 @@ export default {
   computed: {
     ...mapGetters({
       getSortedChatOrder: 'chats/getSortedChatOrder',
-      getNumUnread: 'chats/getNumUnread'
+      getNumUnread: 'chats/getNumUnread',
+      getCurrencyFormat: 'appearance/getCurrencyFormat'
     }),
     relayConnected () {
       return this.$relay.connected
@@ -105,7 +106,7 @@ export default {
       return this.$electrum.connected
     },
     getBalance () {
-      return formatBalance(this.$wallet.balance)
+      return this.formatBalance(this.$wallet.balance)
     }
   }
 }

--- a/src/components/chat/ChatMessage.vue
+++ b/src/components/chat/ChatMessage.vue
@@ -49,6 +49,8 @@ import ChatMessageMenu from '../context_menus/ChatMessageMenu.vue'
 import DeleteMessageDialog from '../dialogs/DeleteMessageDialog'
 import TransactionDialog from '../dialogs/TransactionDialog.vue'
 import { stampPrice } from '../../wallet/helpers'
+import { formatBalance } from '../../utils/formatting'
+import { mapGetters } from 'vuex'
 
 export default {
   components: {
@@ -76,6 +78,9 @@ export default {
     }
   },
   computed: {
+    ...mapGetters({
+      getCurrencyFormat: 'appearance/getCurrencyFormat'
+    }),
     formatedTimestamp () {
       switch (this.message.status) {
         case 'confirmed': {
@@ -99,7 +104,7 @@ export default {
     },
     stampPrice () {
       const amount = stampPrice(this.message.outpoints)
-      return amount + ' sats'
+      return formatBalance(amount, this.getCurrencyFormat)
     }
   }
 }

--- a/src/components/chat/ChatMessageSection.vue
+++ b/src/components/chat/ChatMessageSection.vue
@@ -54,10 +54,11 @@ export default {
   },
   methods: {
     ...mapGetters({
-      getMessageByPayloadVuex: 'chats/getMessageByPayload'
+      getMessageByPayloadVuex: 'chats/getMessageByPayload',
+      getCurrencyFormat: 'appearance/getCurrencyFormat'
     }),
     formatSats (value) {
-      return formatBalance(Number(value))
+      return formatBalance(Number(value), this.getCurrencyFormat)
     },
     showImageDialog (image) {
       this.image = image

--- a/src/components/dialogs/SettingsDialog.vue
+++ b/src/components/dialogs/SettingsDialog.vue
@@ -39,15 +39,21 @@ export default {
           updateInterval: this.getUpdateInterval() / 1_000
         },
         appearance: {
-          darkMode: this.getDarkMode()
+          darkMode: this.getDarkMode(),
+          currencyFormat: this.getCurrencyFormat()
         }
       }
     }
   },
   methods: {
-    ...mapGetters({ getUpdateInterval: 'contacts/getUpdateInterval', getDarkMode: 'appearance/getDarkMode' }),
+    ...mapGetters({
+      getUpdateInterval: 'contacts/getUpdateInterval',
+      getDarkMode: 'appearance/getDarkMode',
+      getCurrencyFormat: 'appearance/getCurrencyFormat'
+    }),
     ...mapActions({
-      darkMode: 'appearance/setDarkMode'
+      darkMode: 'appearance/setDarkMode',
+      setCurrencyFormat: 'appearance/setCurrencyFormat'
     }),
     ...mapMutations({
       updateInterval: 'contacts/setUpdateInterval'
@@ -56,6 +62,7 @@ export default {
       this.darkMode(this.settings.appearance.darkMode)
       this.$q.dark.set(this.settings.appearance.darkMode)
       this.updateInterval(this.settings.networking.updateInterval * 1_000)
+      this.setCurrencyFormat(this.settings.appearance.currencyFormat)
     }
   }
 }

--- a/src/components/dialogs/WalletDialog.vue
+++ b/src/components/dialogs/WalletDialog.vue
@@ -91,9 +91,10 @@ export default {
   },
   computed: {
     ...mapGetters({
+      getCurrencyFormat: 'appearance/getCurrencyFormat'
     }),
     getBalance () {
-      return formatBalance(this.$wallet.balance)
+      return formatBalance(this.$wallet.balance, this.getCurrencyFormat)
     }
   },
   methods: {

--- a/src/components/setup/DepositStep.vue
+++ b/src/components/setup/DepositStep.vue
@@ -94,6 +94,7 @@ import { copyToClipboard } from 'quasar'
 import { numAddresses, recomendedBalance } from '../../utils/constants'
 import { addressCopiedNotify } from '../../utils/notifications'
 import { formatBalance } from '../../utils/formatting'
+import { mapGetters } from 'vuex'
 
 export default {
   components: {
@@ -140,8 +141,11 @@ export default {
       const percentage = 100 * Math.min(this.getBalance() / this.recomendedBalance, 1)
       return percentage
     },
+    ...mapGetters({
+      getCurrencyFormat: 'appearance/getCurrencyFormat'
+    }),
     formatBalance () {
-      return formatBalance(this.getBalance())
+      return formatBalance(this.getBalance(), this.getCurrencyFormat)
     }
   }
 }

--- a/src/store/modules/appearance.js
+++ b/src/store/modules/appearance.js
@@ -1,21 +1,34 @@
 export default {
   namespaced: true,
   state: {
-    darkMode: false
+    darkMode: false,
+    currencyFormat: {
+      type: 'fiat',
+      conversion: 0.000002
+    }
   },
   getters: {
     getDarkMode (state) {
       return state.darkMode
+    },
+    getCurrencyFormat (state) {
+      return state.currencyFormat
     }
   },
   mutations: {
     setDarkMode (state, darkMode) {
       state.darkMode = darkMode
+    },
+    setCurrencyFormat (state, format) {
+      state.currencyFormat = format
     }
   },
   actions: {
     setDarkMode ({ commit }, darkMode) {
       commit('setDarkMode', darkMode)
+    },
+    setCurrencyFormat ({ commit }, format) {
+      commit('setCurrencyFormat', format)
     }
   }
 }

--- a/src/store/modules/appearance.js
+++ b/src/store/modules/appearance.js
@@ -3,8 +3,7 @@ export default {
   state: {
     darkMode: false,
     currencyFormat: {
-      type: 'fiat',
-      conversion: 0.000002
+      type: 'sats'
     }
   },
   getters: {

--- a/src/utils/formatting.js
+++ b/src/utils/formatting.js
@@ -1,16 +1,26 @@
 const cashlib = require('bitcore-lib-cash')
 
-export const formatBalance = function (balance) {
-  if (balance < 1_000) {
-    return String(balance) + ' sats'
-  } else if (balance < 100_000) {
-    return String(balance / 100) + ' uBCH'
-  } else if (balance < 10_000_000) {
-    return String(balance / 100_000) + ' mBCH'
-  } else if (balance < 100_000_000) {
-    return String(balance / 1_000_000) + ' cBCH'
-  } else {
-    return String(balance / 100_000_000) + ' BCH'
+export const formatBalance = function (satoshis, format) {
+  if (format.type === 'sats') {
+    if (satoshis < 1_000) {
+      return String(satoshis) + ' sats'
+    } else if (satoshis < 100_000) {
+      return String(satoshis / 100) + ' uBCH'
+    } else if (satoshis < 10_000_000) {
+      return String(satoshis / 100_000) + ' mBCH'
+    } else if (satoshis < 100_000_000) {
+      return String(satoshis / 1_000_000) + ' cBCH'
+    } else {
+      return String(satoshis / 100_000_000) + ' BCH'
+    }
+  } else if (format.type === 'fiat') {
+    const conversion = format.conversion
+    const cent = satoshis * conversion
+    if (cent < 100) {
+      return Math.floor(cent * 1_000) / 1_000 + '¢'
+    } else {
+      return '$' + (Math.floor(cent * 1_000) / 100_000)
+    }
   }
 }
 


### PR DESCRIPTION
**Motivation**
People may want to change the denomination of the stamp values.

**Implementation**
We introduce an additional argument to the `formatBalance` function which modifies how the stamp value is displayed. This is currently used to denominate in a dummy amount of USD, however could be extended to configure other ways to denominate the stamp value e.g. "how many decimal places mBCH?" etc