### PR TITLE
Restyle chat messages for easier reading, consolidated view

### DIFF
--- a/src/components/chat/ChatMessage.vue
+++ b/src/components/chat/ChatMessage.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="q-pa-none q-ma-sm col rounded-borders bg-dark-3">
+  <div class="q-pa-none q-ma-none q-ml-sm  q-mr-sm col rounded-borders bg-dark-3">
     <!-- Context Menu -->
 
     <!-- Transaction Dialog -->
@@ -21,18 +21,23 @@
       @deleteClick="deleteDialog = true"
       @replyClick="replyClicked({ address, index })"
     />
+    <q-tooltip>
+      <div class="col-auto q-pa-none">
+        <div class="row-auto">{{stampPrice}}</div>
+        <div class="row-auto">{{timestampString}}</div>
+      </div>
+    </q-tooltip>
 
     <div class="row">
-      <div class="col-auto q-pa-sm" style="min-width: 100px">
-        <div class="row-auto">{{stampPrice}}</div>
-        <div class="row-auto">{{formatedTimestamp}}</div>
-      </div>
       <div class="col">
         <!-- TODO: Assign random color based on seed from name -->
-        <div class="col text-weight-bold" style="border-bottom: 1px solid grey;">{{contact.name}}</div>
+        <div class="col text-weight-bold" style="border-bottom: 1px solid grey;" v-if="showHeader">{{contact.name}}</div>
         <chat-message-section :key="index" :items="message.items" :address="address" />
       </div>
-
+      <div class="col-auto" style="min-width: 100px">
+        <div class="col text-weight-bold" style="border-bottom: 1px solid grey;" v-if="showHeader">&nbsp;</div>
+        <div class="row-auto">{{shortTimestamp}}</div>
+      </div>
       <div v-if="message.status==='error'" class="row justify-end q-pt-xs" style="full-width">
         <div class="col-auto">
           <q-icon name="error" color="red" />
@@ -68,7 +73,11 @@ export default {
     message: Object,
     contact: Object,
     index: String,
-    now: Object
+    now: Object,
+    showHeader: {
+      type: Boolean,
+      default: () => true
+    }
   },
   methods: {
     replyClicked (args) {
@@ -76,7 +85,7 @@ export default {
     }
   },
   computed: {
-    formatedTimestamp () {
+    shortTimestamp () {
       switch (this.message.status) {
         case 'confirmed': {
           const timestamp = this.message.timestamp || this.message.serverTime
@@ -96,6 +105,10 @@ export default {
           return ''
       }
       return 'unknown'
+    },
+    timestampString () {
+      const timestamp = this.message.timestamp || this.message.serverTime
+      return moment(timestamp)
     },
     stampPrice () {
       const amount = stampPrice(this.message.outpoints)

--- a/src/components/chat/ChatMessageSection.vue
+++ b/src/components/chat/ChatMessageSection.vue
@@ -1,25 +1,25 @@
 <template>
-  <div>
+  <div class='q-ml-sm'>
     <q-dialog v-model="imageDialog">
       <image-dialog :image="image" />
     </q-dialog>
 
     <template v-for="(item, index) in items">
-      <div class="row-auto q-pa-sm text-left bg-info rounded-borders" v-bind:key="index" v-if="item.type=='reply'">
+      <div class="row-auto q-pt-xs text-left rounded-borders" v-bind:key="index" v-if="item.type=='reply'">
         <span class="text-weight-bold">Replying To:</span>
         <chat-message-section
-          class="q-pa-sm row-auto "
+          :class="`q-pa-xs row-auto ${$q.dark.isActive ? 'bg-indigo-10' : 'bg-light-blue-4'}`"
           style="border-radius: 5px;"
           :items="getMessage(item.payloadDigest).items"
           :address="address"
         />
       </div>
       <div
-        class="row-auto q-pa-sm text-left"
+        class="row-auto q-pa-xs text-left"
         v-bind:key="index"
         v-if="item.type=='text'"
       >{{ item.text }}</div>
-      <div class="row-auto q-pa-sm text-left" v-bind:key="index" v-if="item.type=='image'">
+      <div class="row-auto q-pt-xs text-left" v-bind:key="index" v-if="item.type=='image'">
         <q-img
           :src="item.image"
           contain
@@ -27,7 +27,7 @@
           @click="()=> showImageDialog(item.image)"
         />
       </div>
-      <div class="row-auto q-pa-sm text-left" v-bind:key="index" v-if="item.type=='stealth'">
+      <div class="row-auto q-pt-xs text-left" v-bind:key="index" v-if="item.type=='stealth'">
         <q-icon name="attach_money" size="sm" dense />
         {{ formatSats(item.amount) }}
       </div>

--- a/src/pages/Chat.vue
+++ b/src/pages/Chat.vue
@@ -28,11 +28,12 @@
             index="NA"
             key="NA"
           />
-          <template v-for="chatMessage in messages">
+          <template v-for="(chatMessage, index) in messages">
             <chat-message
               :key="chatMessage.payloadDigest"
               :address="address"
               :message="chatMessage"
+              :showHeader="shouldShowHeader(chatMessage, messages[index-1])"
               :contact="getContact(chatMessage.outbound)"
               :index="chatMessage.payloadDigest"
               :now="now"
@@ -199,6 +200,12 @@ export default {
     },
     setReply (index) {
       this.replyDigest = index
+    },
+    shouldShowHeader (message, previousMessage) {
+      if (previousMessage === undefined) {
+        return true
+      }
+      return previousMessage.senderAddress !== message.senderAddress
     }
   },
   computed: {

--- a/src/relay/client.js
+++ b/src/relay/client.js
@@ -307,10 +307,10 @@ export class RelayClient {
       }
     )
     const { serializedPayload, payloadDigest } = constructPayload(entries, privKey, destPubKey, 1)
-
+    const senderAddress = this.wallet.myAddressStr
     // Add localy
     const payloadDigestHex = payloadDigest.toString('hex')
-    this.events.emit('messageSending', { addr, index: payloadDigestHex, items, outpoints, transactions })
+    this.events.emit('messageSending', { addr, senderAddress, index: payloadDigestHex, items, outpoints, transactions })
 
     // Construct message
     try {
@@ -337,7 +337,7 @@ export class RelayClient {
         return client.request('blockchain.transaction.broadcast', transaction.toString())
       }))
         .then(() => this.pushMessages(destAddr, messageSet))
-        .then(() => this.events.emit('messageSent', { addr, index: payloadDigestHex, items, outpoints, transactions }))
+        .then(() => this.events.emit('messageSent', { addr, senderAddress, index: payloadDigestHex, items, outpoints, transactions }))
         .catch((err) => {
           console.error(err)
           if (err.response) {
@@ -347,11 +347,11 @@ export class RelayClient {
           // TODO: More subtle
           usedIDs.forEach(id => wallet.fixFrozenUTXO(id))
 
-          this.events.emit('messageSendError', { addr, index: payloadDigestHex, outpoints, transactions, items, err })
+          this.events.emit('messageSendError', { addr, senderAddress, index: payloadDigestHex, outpoints, transactions, items, err })
         })
     } catch (err) {
       console.error(err)
-      this.events.emit('messageSendError', { addr, index: payloadDigestHex, items, outpoints, transactions })
+      this.events.emit('messageSendError', { addr, senderAddress, index: payloadDigestHex, items, outpoints, transactions })
     }
   }
 
@@ -570,7 +570,8 @@ export class RelayClient {
       items: [],
       serverTime,
       receivedTime,
-      outpoints
+      outpoints,
+      senderAddress: senderAddr
     }
     for (const index in entriesList) {
       const entry = entriesList[index]

--- a/src/store/modules/chats.js
+++ b/src/store/modules/chats.js
@@ -166,7 +166,7 @@ export default {
       }
       state.activeChatAddr = addr
     },
-    sendMessageLocal (state, { addr, index, items, outpoints = [], status = 'pending', retryData = null }) {
+    sendMessageLocal (state, { addr, senderAddress, index, items, outpoints = [], status = 'pending', retryData = null }) {
       const timestamp = Date.now()
       const newMsg = {
         outbound: true,
@@ -175,7 +175,8 @@ export default {
         serverTime: timestamp,
         receivedTime: timestamp,
         outpoints,
-        retryData
+        retryData,
+        senderAddress
       }
       assert(newMsg.outbound !== undefined)
       assert(newMsg.status !== undefined)
@@ -183,6 +184,7 @@ export default {
       assert(newMsg.serverTime !== undefined)
       assert(newMsg.items !== undefined)
       assert(newMsg.outpoints !== undefined)
+      assert(newMsg.senderAddress !== undefined, 'missing sender address')
 
       const message = { payloadDigest: index, ...newMsg }
       if (index in state.messages) {
@@ -216,6 +218,7 @@ export default {
       assert(newMsg.serverTime !== undefined)
       assert(newMsg.items !== undefined)
       assert(newMsg.outpoints !== undefined)
+      assert(newMsg.senderAddress !== undefined)
 
       const message = { payloadDigest: index, ...newMsg }
       if (index in state.messages) {

--- a/src/utils/relay-client-factory.js
+++ b/src/utils/relay-client-factory.js
@@ -20,15 +20,15 @@ export function getRelayClient ({ wallet, electrumClient, store, relayUrl = defa
     console.log(err)
   })
   client.events.on('opened', () => { observables.connected = true })
-  client.events.on('messageSending', ({ addr, index, items, outpoints, transactions }) => {
-    store.commit('chats/sendMessageLocal', { addr, index, items, outpoints, transactions })
+  client.events.on('messageSending', ({ addr, senderAddress, index, items, outpoints, transactions }) => {
+    store.commit('chats/sendMessageLocal', { addr, senderAddress, index, items, outpoints, transactions })
   })
-  client.events.on('messageSendError', ({ addr, index, items, outpoints, transactions, retryData }) => {
-    store.commit('chats/sendMessageLocal', { addr, index, items, outpoints, transactions, retryData, status: 'error' })
+  client.events.on('messageSendError', ({ addr, senderAddress, index, items, outpoints, transactions, retryData }) => {
+    store.commit('chats/sendMessageLocal', { addr, senderAddress, index, items, outpoints, transactions, retryData, status: 'error' })
   })
-  client.events.on('messageSent', ({ addr, index, items, outpoints, transactions }) => {
+  client.events.on('messageSent', ({ addr, senderAddress, index, items, outpoints, transactions }) => {
     // TODO: Why no items here?
-    store.commit('chats/sendMessageLocal', { addr, index, items, outpoints, transactions, status: 'confirmed' })
+    store.commit('chats/sendMessageLocal', { addr, senderAddress, index, items, outpoints, transactions, status: 'confirmed' })
   })
   client.events.on('receivedMessage', (args) => {
     // TODO: Why no items here?


### PR DESCRIPTION
This commit removes headers between messages from the same person in a
particular chat. It also moves the stamp amounts to a tooltip. The
timestamps are shifted to the right. This is the start of a broader
effort to make the chats prettier.