### PR TITLE
Ensure proper set of state is maintained to disk and restored

### DIFF
--- a/src/store/modules/chats.js
+++ b/src/store/modules/chats.js
@@ -149,7 +149,7 @@ export default {
       if (values.length === 0) {
         state.chats[addr].lastRead = null
       } else {
-        state.chats[addr].lastRead = values[values.length - 1].serverTime
+        state.chats[addr].lastRead = Math.max(values[values.length - 1].serverTime, state.chats[addr].lastRead)
       }
       state.chats[addr].totalUnreadMessages = 0
       state.chats[addr].totalUnreadValue = 0

--- a/src/store/modules/contacts.js
+++ b/src/store/modules/contacts.js
@@ -5,6 +5,15 @@ import KeyserverHandler from '../../keyserver/handler'
 import Vue from 'vue'
 import moment from 'moment'
 
+export function rehydrateContacts (contactState) {
+  if (!contactState) {
+    return
+  }
+
+  // This is currentlœy a shim, we don't need any special rehydrate contact at this time.
+  contactState.contacts = contactState.contacts || {}
+}
+
 export default {
   namespaced: true,
   state: {


### PR DESCRIPTION
There were a couple keys that were being saved/restored incorrectly.
Specifically the list of chat participants. Additionally, information
about contacts were not being stored at all. This commit adds that
information back. This ensures tons of "unread" message notifications
do not pop up when the client is restarted.