### PR TITLE
Fix issue with chat `bottom` variable not set properly on load

### DIFF
--- a/src/pages/Chat.vue
+++ b/src/pages/Chat.vue
@@ -183,8 +183,8 @@ export default {
       const scrollArea = this.$refs.chatScroll
       const scrollTarget = scrollArea.getScrollTarget()
       if (
-        scrollTarget.scrollHeight ===
-        details.position + scrollTarget.offsetHeight
+        // Ten pixels from bottom
+        details.position + scrollTarget.offsetHeight - scrollTarget.scrollHeight <= 10
       ) {
         this.bottom = true
       } else {


### PR DESCRIPTION
Currently, we were only setting bottom if the scroll was *at the bottom*
However, there are times when the chat view is *more* than the
currently loaded number of chats. In this case, bottom was not being
set properly. As a result, scrolling to bottom was not occuring
properly on first load.