### PR TITLE
Make hiding components during load more fine-grained

### DIFF
--- a/src/components/chat/ChatList.vue
+++ b/src/components/chat/ChatList.vue
@@ -30,6 +30,7 @@
           :chatAddr="contact.address"
           :valueUnread="formatBalance(contact.totalUnreadValue)"
           :numUnread="contact.totalUnreadMessages"
+          :loaded="loaded"
         />
         <q-item v-if="getSortedChatOrder.length === 0">
           <q-item-section>
@@ -65,7 +66,7 @@ import NewContactDialog from '../dialogs/NewContactDialog.vue'
 import RelayConnectDialog from '../dialogs/RelayConnectDialog.vue'
 
 export default {
-  props: ['chatAddr'],
+  props: ['chatAddr', 'loaded'],
   components: {
     ChatListItem,
     WalletDialog,

--- a/src/components/chat/ChatListItem.vue
+++ b/src/components/chat/ChatListItem.vue
@@ -15,6 +15,7 @@
       <q-item-label
         caption
         lines="2"
+        v-if="loaded"
       >{{ latestMessageBody }}</q-item-label>
     </q-item-section>
     <q-item-section
@@ -22,13 +23,13 @@
       top
     >
       <q-badge
-        v-if="!!valueUnread"
+        v-if="!!valueUnread && loaded"
         color="primary"
         :label="valueUnread"
         class="q-my-xs"
       />
       <q-badge
-        v-if="!!numUnread"
+        v-if="!!numUnread && loaded"
         color="secondary"
         :label="numUnread"
         class="q-my-xs"
@@ -68,6 +69,6 @@ export default {
       return this.getActiveChat === this.chatAddr
     }
   },
-  props: ['chatAddr', 'numUnread', 'valueUnread']
+  props: ['chatAddr', 'numUnread', 'valueUnread', 'loaded']
 }
 </script>

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -2,7 +2,6 @@
   <q-layout view="hHr LpR lff">
     <q-drawer
       v-model="myDrawerOpen"
-      v-if="loaded"
       overlay
       bordered
       behavior="mobile"
@@ -11,7 +10,7 @@
     >
       <settings-panel />
     </q-drawer>
-    <q-drawer v-model="contactDrawerOpen" v-if="loaded" side="right" :width="300" :breakpoint="400" bordered>
+    <q-drawer v-model="contactDrawerOpen" side="right" :width="300" :breakpoint="400" bordered>
       <contact-panel
         v-if="activeChatAddr !== null"
         :address="activeChatAddr"
@@ -19,14 +18,14 @@
       />
     </q-drawer>
     <q-page-container>
-      <q-page :style-fn="tweak" v-if="loaded">
+      <q-page :style-fn="tweak">
         <q-splitter
           v-model="splitterRatio"
           class="full-height"
           unit="px"
         >
           <template v-slot:before>
-            <chat-list class="full-height" @toggleContactDrawerOpen="toggleContactDrawerOpen" @toggleMyDrawerOpen="toggleMyDrawerOpen" />
+            <chat-list class="full-height" :loaded="loaded" @toggleContactDrawerOpen="toggleContactDrawerOpen" @toggleMyDrawerOpen="toggleMyDrawerOpen" />
           </template>
 
           <template v-slot:after>
@@ -38,6 +37,7 @@
               :messages="item.messages"
               :active="activeChatAddr === index"
               :style="`height: inherit; min-height: inherit;`"
+              :loaded="loaded"
             />
           </template>
         </q-splitter>
@@ -99,12 +99,6 @@ export default {
   },
   created () {
     this.$q.dark.set(this.getDarkMode())
-    // Start relay listener
-    this.$q.loading.show({
-      delay: 0,
-      message: 'Updating messages and checking wallet integrity...'
-    })
-
     console.log('loading')
 
     if (!this.activeChatAddr) {
@@ -124,13 +118,11 @@ export default {
         console.log(`Loading messages took ${t1 - t0}ms`)
         this.$wallet.init()
         console.log('loaded')
+        this.loaded = true
       })
     } catch (err) {
       console.error(err)
     }
-
-    this.loaded = true
-    this.$q.loading.hide()
   }
 }
 </script>

--- a/src/pages/Chat.vue
+++ b/src/pages/Chat.vue
@@ -28,8 +28,9 @@
             index="NA"
             key="NA"
           />
-          <template v-for="(chatMessage, index) in messages">
+          <template v-if="loaded || active">
             <chat-message
+              v-for="(chatMessage, index) in messages"
               :key="chatMessage.payloadDigest"
               :address="address"
               :message="chatMessage"
@@ -96,6 +97,10 @@ export default {
     messages: {
       type: Array,
       default: () => []
+    },
+    loaded: {
+      type: Boolean,
+      default: () => false
     },
     active: {
       type: Boolean,


### PR DESCRIPTION
This commit moves the `v-if`s for various components being hidden during
load to be more granular. Ideally, this should be done in a more
holistic way. However, this is a short-term hack for today's release to
ensure that things appear correctly for users.
