### PR TITLE
Remove no longer necessary loading plugin

### DIFF
--- a/quasar.conf.js
+++ b/quasar.conf.js
@@ -59,7 +59,7 @@ module.exports = configure(function (ctx) {
       directives: [],
 
       // Quasar plugins
-      plugins: ['Notify', 'Loading', 'Dialog']
+      plugins: ['Notify', 'Dialog']
     },
 
     // https://quasar.dev/quasar-cli/cli-documentation/supporting-ie

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -99,11 +99,6 @@ export default {
   },
   created () {
     this.$q.dark.set(this.getDarkMode())
-    // Start relay listener
-    this.$q.loading.show({
-      delay: 0,
-      message: 'Updating messages and checking wallet integrity...'
-    })
 
     console.log('loading')
 
@@ -130,7 +125,6 @@ export default {
     }
 
     this.loaded = true
-    this.$q.loading.hide()
   }
 }
 </script>


### PR DESCRIPTION
Load times are unacceptable. Therefor, remove this stopgap as we have
ensured that the gui is responsive during load. We will commit to
ensuring that load times are snappy in the future.
