### PR TITLE
Ensure wallet init happens on load

### DIFF
--- a/src/boot/setup-apis.js
+++ b/src/boot/setup-apis.js
@@ -107,6 +107,7 @@ export default async ({ store, Vue }) => {
   if (xPrivKey) {
     console.log('Loaded previous private key')
     wallet.setXPrivKey(xPrivKey)
+    await wallet.init()
   }
   const { client: relayClient, observables: relayObservables } = getRelayClient({ relayUrl: defaultRelayUrl, wallet, electrumObservables, store })
   const relayToken = store.getters['relayClient/getToken']

--- a/src/relay/client.js
+++ b/src/relay/client.js
@@ -696,6 +696,12 @@ export class RelayClient {
         }, 0)
       })
     }
+
+    const t0 = performance.now()
+    await this.wallet.fixUTXOs().then(() => {
+      const fixUTXOsTime = performance.now()
+      console.log(`fixUTXOsTime UTXOs took ${fixUTXOsTime - t0} ms`)
+    })
   }
 }
 

--- a/src/wallet/index.js
+++ b/src/wallet/index.js
@@ -75,13 +75,6 @@ export class Wallet {
     console.log(`updateUTXOTime UTXOs took ${updateUTXOTime - t0} ms`)
     console.log(`startListenersTime UTXOs took ${startListenersTime - t0} ms`)
     console.log(`fixFrozenUTXOsTime UTXOs took ${fixFrozenUTXOsTime - t0} ms`)
-
-    // Do this async.  It takes 23 seconds.
-    // Omit this step
-    // this.fixUTXOs().then(() => {
-    //   const fixUTXOsTime = performance.now()
-    //   console.log(`fixUTXOsTime UTXOs took ${fixUTXOsTime - t0} ms`)
-    // })
   }
 
   get xPrivKey () {


### PR DESCRIPTION
This commit ensure wallet init happens on load.  However, it also moves
the UTXO refresh call into the relay client. This ensures that the time
consuming update occurs only when it would be relevant. That is, after
all messages have been loaded and UTXOs that were sent out being
removed.