### PR TITLE
Fix stamp output removal on message load

### DIFF
--- a/src/store/modules/wallet.js
+++ b/src/store/modules/wallet.js
@@ -65,7 +65,9 @@ export default {
       Vue.delete(state.frozenUTXOs, id)
     },
     addUTXO (state, output) {
-      Vue.set(state.utxos, calcId(output), output)
+      const utxoId = calcId(output)
+      console.log('adding utxo', utxoId)
+      Vue.set(state.utxos, utxoId, output)
     },
     freezeUTXO (state, id) {
       const frozenUTXO = state.utxos[id]

--- a/src/wallet/index.js
+++ b/src/wallet/index.js
@@ -136,7 +136,7 @@ export class Wallet {
     // Delete all utxos by address
     Object.entries(this.storage.getUTXOs()).forEach(([id, utxo]) => {
       if (utxo.address === addr) {
-        this.storage.removeUTXO(id)
+        this.removeUTXO(id)
       }
     })
     // Make a copy so this is not mutated
@@ -239,7 +239,7 @@ export class Wallet {
               return (output.tx_hash === utxo.txId) && (output.tx_pos === utxo.outputIndex)
             })) {
             // No such utxo
-              this.storage.removeUTXO(id)
+              this.removeUTXO(id)
             }
           } catch (err) {
             console.error('error deserializing utxo address', err, utxo)
@@ -256,6 +256,7 @@ export class Wallet {
       'blockchain.scripthash.subscribe',
       async (result) => {
         const scriptHash = result[0]
+        console.log('Subscription hit', result)
         await this.updateUTXOFromScriptHash(scriptHash)
       })
 
@@ -504,6 +505,12 @@ export class Wallet {
   }
 
   removeUTXO (id) {
+    const utxos = this.storage.getUTXOs()
+    if (!(id in utxos)) {
+      console.log(id, 'missing from UTXO set?')
+      return
+    }
+    console.log('removing utxo', id)
     // TODO: Nobody should be calling this outside of the wallet
     return this.storage.removeUTXO(id)
   }


### PR DESCRIPTION
Due to a mistake on my part, we were attempting to remove outpoints
which were sent to the recipient of messages. Of course, this won't work
as they are not our outpoints. This commit addresses this by instead
removing outpoints we *used* to generate the stamp/stealth tx.
