### PR TITLE
Do not refresh UTXO state for stamps/stealth txns

### DIFF
--- a/src/relay/client.js
+++ b/src/relay/client.js
@@ -697,11 +697,11 @@ export class RelayClient {
       })
     }
 
-    const t0 = performance.now()
-    await this.wallet.fixUTXOs().then(() => {
-      const fixUTXOsTime = performance.now()
-      console.log(`fixUTXOsTime UTXOs took ${fixUTXOsTime - t0} ms`)
-    })
+    // const t0 = performance.now()
+    // await this.wallet.fixUTXOs().then(() => {
+    //   const fixUTXOsTime = performance.now()
+    //   console.log(`fixUTXOsTime UTXOs took ${fixUTXOsTime - t0} ms`)
+    // })
   }
 }
 


### PR DESCRIPTION
Due to a previous update, the client now properly updates its internal
UTXO set state from the relay server. As such, spamming electrum with
significant numbers of `listunspent` requests is no longer necessary.
It is still possible that due to reorgs that we get out of sync.
However, this can be solved by fixing those utxos and re-trying when
we attempt to use them to send a message.
