### PR TITLE
Fix deletion of messages

### DIFF
--- a/src/components/chat/ChatMessage.vue
+++ b/src/components/chat/ChatMessage.vue
@@ -10,16 +10,17 @@
 
     <!-- Delete Dialog -->
     <q-dialog v-model="deleteDialog">
-      <delete-message-dialog :address="address" :index="index" />
+      <delete-message-dialog :address="address" :payloadDigest="payloadDigest" :index="index" />
     </q-dialog>
 
     <chat-message-menu
       :address="address"
-      :id="index"
+      :payloadDigest="payloadDigest"
       :message="message"
+      :index="index"
       @txClick="transactionDialog = true"
       @deleteClick="deleteDialog = true"
-      @replyClick="replyClicked({ address, index })"
+      @replyClick="replyClicked({ address, payloadDigest })"
     />
     <q-tooltip>
       <div class="col-auto q-pa-none">
@@ -73,7 +74,8 @@ export default {
     address: String,
     message: Object,
     contact: Object,
-    index: String,
+    payloadDigest: String,
+    index: Number,
     now: Object,
     showHeader: {
       type: Boolean,

--- a/src/components/context_menus/ChatMessageMenu.vue
+++ b/src/components/context_menus/ChatMessageMenu.vue
@@ -63,7 +63,7 @@ import { mapMutations, mapGetters } from 'vuex'
 import { copyToClipboard } from 'quasar'
 
 export default {
-  props: ['address', 'id', 'message'],
+  props: ['address', 'payloadDigest', 'index', 'message'],
   methods: {
     ...mapMutations({
       deleteMessage: 'chats/deleteMessage'
@@ -81,7 +81,7 @@ export default {
       this.$relayClient.sendImage(args)
     },
     resend () {
-      this.deleteMessage({ addr: this.address, id: this.id })
+      this.$relayClient.sendMessageImpl(this.message)
       const stampAmount = this.getStampAmount()(this.address)
       this.$relayClient.sendMessageImpl({ addr: this.address, items: this.message.items, stampAmount })
     },

--- a/src/components/dialogs/DeleteMessageDialog.vue
+++ b/src/components/dialogs/DeleteMessageDialog.vue
@@ -30,7 +30,7 @@
 <script>
 import { mapMutations } from 'vuex'
 export default {
-  props: ['address', 'index'],
+  props: ['address', 'payloadDigest', 'index'],
   methods: {
     ...mapMutations({
       deleteMessage: 'chats/deleteMessage'
@@ -39,10 +39,10 @@ export default {
       // TODO: Move this into wallet API
       // TODO: More private
       // Delete message from relay server
-      await this.$relayClient.deleteMessage(this.index)
+      await this.$relayClient.deleteMessage(this.payloadDigest)
       // Delete message from relay server
       try {
-        this.deleteMessage({ addr: this.address, id: this.index })
+        this.deleteMessage({ addr: this.address, payloadDigest: this.payloadDigest, index: this.index })
       } catch (err) {
         console.error(err)
         if (err.response) {

--- a/src/pages/Chat.vue
+++ b/src/pages/Chat.vue
@@ -25,7 +25,8 @@
             :sent="false"
             :contact="{name: 'Stamp Developers'}"
             :message="{items: [{type:'text', text: donationMessage}], status: 'confirmed', outpoints: [], timestamp: new Date()}"
-            index="NA"
+            :index="-1"
+            payloadDigest="NA"
             key="NA"
           />
           <template v-if="loaded || active">
@@ -36,10 +37,11 @@
               :message="chatMessage"
               :showHeader="shouldShowHeader(chatMessage, messages[index-1])"
               :contact="getContact(chatMessage.outbound)"
-              :index="chatMessage.payloadDigest"
+              :payloadDigest="chatMessage.payloadDigest"
+              :index="index"
               :now="now"
               :nameColor="chatMessage.outbound ? '': nameColor"
-              @replyClicked="({ address, index }) => setReply(index)"
+              @replyClicked="({ address, payloadDigest }) => setReply(payloadDigest)"
             />
           </template>
           <q-scroll-observer debounce="500" @scroll="scrollHandler" />

--- a/src/store/modules/chats.js
+++ b/src/store/modules/chats.js
@@ -144,8 +144,8 @@ export default {
     }
   },
   mutations: {
-    deleteMessage (state, { addr, id }) {
-      Vue.delete(state.chats[addr].messages, id)
+    deleteMessage (state, { addr, index }) {
+      state.chats[addr].messages.splice(index, 1)
     },
     readAll (state, addr) {
       const values = state.chats[addr].messages


### PR DESCRIPTION
During a previous refactor we changed the message list to a simple
array from a map indexed by payloadDigest. This commit adjusts a number
of various props on components to pass through this index. Thus enabling
delete to function properly by updating the array by array index (rather
than attempting to delete a non-existant key).
