### PR TITLE
Fix `Cannot read property lastRead of undefined`

### DIFF
--- a/src/store/modules/chats.js
+++ b/src/store/modules/chats.js
@@ -96,7 +96,7 @@ export default {
       return sortedOrder
     },
     lastRead: (state) => (addr) => {
-      return state.chats[addr].lastRead
+      return addr in state.chats ? state.chats[addr].lastRead : 0
     },
     getStampAmount: (state) => (addr) => {
       return state.chats[addr].stampAmount || defaultStampAmount


### PR DESCRIPTION
When first receiving a message from a new contact, the chat is undefin-
ed. As such, the `chats[addr]` is undefined, and it impossible to look
up the `lastRead` field. This commit checks to see if the "chat" exists
and returns zero if not. That prevents this error from being hit.
