### PR TITLE
Fix default chat message list to be appropriate type

### DIFF
--- a/src/store/modules/chats.js
+++ b/src/store/modules/chats.js
@@ -165,7 +165,7 @@ export default {
     },
     setActiveChat (state, addr) {
       if (!(addr in state.chats)) {
-        Vue.set(state.chats, addr, { ...defaultContactObject, messages: {}, address: addr })
+        Vue.set(state.chats, addr, { ...defaultContactObject, messages: [], address: addr })
       }
       state.activeChatAddr = addr
     },


### PR DESCRIPTION
In a previous refactor the messages store (per chat) was switched
to an array from an object. However, a few places were missed because
javascript is not typesafe. This commit addresses the problem when a new
contact is added. In the future this should be address more holistically
by moving these files to typescript.