### PR TITLE
Fix exit behavior on mac

### DIFF
--- a/src-electron/main-process/electron-main.js
+++ b/src-electron/main-process/electron-main.js
@@ -87,7 +87,17 @@ function createWindow () {
 
   mainWindow.loadURL(process.env.APP_URL)
 
+  let forceQuit = false
+  if (process.platform === 'darwin') {
+    app.on('before-quit', function () {
+      forceQuit = true
+    })
+  }
+
   mainWindow.on('close', function (event) {
+    if (forceQuit) {
+      return
+    }
     event.preventDefault()
     mainWindow.hide()
   })


### PR DESCRIPTION
In order to stop the app from exiting, we were preventing the default
handler for the `close` event in electron. However, on a mac this makes
it so that the app won't exit on shutdown or a menu shutdown. This
commit updates the main event handlers to check if the app is being
`quit` on MacOS (vs just having the window closed).
