### PR TITLE
Remove extranous retry call for failed messages

### DIFF
--- a/src/components/context_menus/ChatMessageMenu.vue
+++ b/src/components/context_menus/ChatMessageMenu.vue
@@ -81,7 +81,6 @@ export default {
       this.$relayClient.sendImage(args)
     },
     resend () {
-      this.$relayClient.sendMessageImpl(this.message)
       const stampAmount = this.getStampAmount()(this.address)
       this.$relayClient.sendMessageImpl({ addr: this.address, items: this.message.items, stampAmount })
     },


### PR DESCRIPTION
Remove an extranous call to `sendMessageImpl` when attempting to retry
sending a transaction. Probably an artifact of a failed merge.
