### PR TITLE
Fix app reload

### DIFF
--- a/src-electron/main-process/electron-main.js
+++ b/src-electron/main-process/electron-main.js
@@ -107,8 +107,10 @@ function createWindow () {
   })
 
   mainWindow.webContents.on('will-navigate', (e, url) => {
-    e.preventDefault()
-    shell.openExternal(url)
+    if (url !== e.sender.getURL()) {
+      e.preventDefault()
+      shell.openExternal(url)
+    }
   })
 }
 


### PR DESCRIPTION
Fixes bug by preventing external shell from opening when the developer framework reloads the app.