### PR TITLE
Compact sidebar

### DIFF
--- a/src/components/chat/ChatList.vue
+++ b/src/components/chat/ChatList.vue
@@ -92,7 +92,7 @@ export default {
   methods: {
     formatBalance (balance) {
       if (!balance) {
-        return balance
+        return
       }
       return formatBalance(balance)
     },

--- a/src/components/chat/ChatList.vue
+++ b/src/components/chat/ChatList.vue
@@ -18,7 +18,7 @@
     <q-toolbar>
       <q-btn class="q-px-sm" flat dense @click="toggleMyDrawerOpen" icon="menu" />
       <q-space />
-      <q-btn class="q-px-sm" flat dense @click="newContactOpen = true" icon="add" />
+      <q-btn v-if="!compact" class="q-px-sm" flat dense @click="newContactOpen = true" icon="add" />
     </q-toolbar>
     <q-scroll-area class="q-px-none col">
       <q-list>
@@ -30,6 +30,7 @@
           :valueUnread="formatBalance(contact.totalUnreadValue)"
           :numUnread="contact.totalUnreadMessages"
           :loaded="loaded"
+          :compact="compact"
         />
         <q-item v-if="getSortedChatOrder.length === 0">
           <q-item-section>
@@ -40,7 +41,7 @@
     </q-scroll-area>
     <q-list>
       <q-separator />
-      <q-item clickable @click="walletOpen=true">
+      <q-item v-show="!compact" clickable @click="walletOpen=true">
         <q-item-section>
           <q-item-label>Balance</q-item-label>
           <q-item-label caption>{{ getBalance }}</q-item-label>
@@ -65,7 +66,16 @@ import NewContactDialog from '../dialogs/NewContactDialog.vue'
 import RelayConnectDialog from '../dialogs/RelayConnectDialog.vue'
 
 export default {
-  props: ['chatAddr', 'loaded'],
+  props: {
+    loaded: {
+      type: Boolean,
+      required: true
+    },
+    compact: {
+      type: Boolean,
+      required: true
+    }
+  },
   components: {
     ChatListItem,
     WalletDialog,

--- a/src/components/chat/ChatListItem.vue
+++ b/src/components/chat/ChatListItem.vue
@@ -8,6 +8,14 @@
     <q-item-section avatar>
       <q-avatar rounded>
         <img :src="contact.avatar">
+        <q-badge
+          v-show="compact"
+          v-if="!!numUnread && loaded"
+          floating
+          color="secondary"
+          :label="numUnread"
+          class="q-my-xs"
+        />
       </q-avatar>
     </q-item-section>
     <q-item-section v-show="!compact">
@@ -19,6 +27,7 @@
       >{{ latestMessageBody }}</q-item-label>
     </q-item-section>
     <q-item-section
+      v-show="!compact"
       side
       top
     >

--- a/src/components/chat/ChatListItem.vue
+++ b/src/components/chat/ChatListItem.vue
@@ -10,7 +10,7 @@
         <img :src="contact.avatar">
       </q-avatar>
     </q-item-section>
-    <q-item-section>
+    <q-item-section v-show="!compact">
       <q-item-label>{{ contact.name }}</q-item-label>
       <q-item-label
         caption
@@ -69,6 +69,27 @@ export default {
       return this.getActiveChat === this.chatAddr
     }
   },
-  props: ['chatAddr', 'numUnread', 'valueUnread', 'loaded']
+  props: {
+    chatAddr: {
+      type: String,
+      required: true
+    },
+    numUnread: {
+      type: Number,
+      required: true
+    },
+    valueUnread: {
+      type: Number,
+      required: true
+    },
+    loaded: {
+      type: Boolean,
+      required: true
+    },
+    compact: {
+      type: Boolean,
+      required: true
+    }
+  }
 }
 </script>

--- a/src/components/chat/ChatListItem.vue
+++ b/src/components/chat/ChatListItem.vue
@@ -76,11 +76,13 @@ export default {
     },
     numUnread: {
       type: Number,
-      required: true
+      // Not passed when all read
+      required: false
     },
     valueUnread: {
-      type: Number,
-      required: true
+      type: String,
+      // Not passed when all read
+      required: false
     },
     loaded: {
       type: Boolean,

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -28,9 +28,16 @@
           class="full-height"
           unit="px"
           separator-style="width: 0px;"
+          emit-immediately
+          :limits="[compactWidth, 1000]"
         >
           <template v-slot:before>
-            <chat-list class="full-height" :loaded="loaded" @toggleMyDrawerOpen="toggleMyDrawerOpen" />
+            <chat-list
+              class="full-height"
+              :loaded="loaded"
+              @toggleMyDrawerOpen="toggleMyDrawerOpen"
+              :compact="compact"
+            />
           </template>
 
           <template v-slot:after>
@@ -58,6 +65,11 @@ import ChatList from '../components/chat/ChatList.vue'
 import SettingsPanel from '../components/panels/SettingsPanel.vue'
 import ContactPanel from '../components/panels/ContactPanel.vue'
 import { mapActions, mapGetters, mapState } from 'vuex'
+import { debounce } from 'quasar'
+
+const compactWidth = 70
+const compactCutoff = 250
+const compactMidpoint = (compactCutoff + compactWidth) / 2
 
 export default {
   components: {
@@ -68,10 +80,12 @@ export default {
   },
   data () {
     return {
-      splitterRatio: 200,
+      trueSplitterRatio: compactCutoff,
       loaded: false,
       myDrawerOpen: false,
-      contactDrawerOpen: false
+      contactDrawerOpen: false,
+      compact: false,
+      compactWidth
     }
   },
   methods: {
@@ -86,13 +100,14 @@ export default {
       const height = viewportHeight - offset + 'px'
       return { height, minHeight: height }
     },
-    setSplitRatio (value) {
-      this.splitterRatio = value
-    },
     toggleContactDrawerOpen () {
       this.contactDrawerOpen = !this.contactDrawerOpen
     },
     toggleMyDrawerOpen () {
+      if (this.compact) {
+        this.compact = false
+        this.trueSplitterRatio = compactCutoff
+      }
       this.myDrawerOpen = !this.myDrawerOpen
     }
   },
@@ -101,7 +116,26 @@ export default {
     ...mapGetters({
       getContact: 'contacts/getContact',
       lastReceived: 'chats/getLastReceived'
-    })
+    }),
+    splitterRatio: {
+      get: function () {
+        return this.trueSplitterRatio
+      },
+      set: debounce(function (inputRatio) {
+        this.trueSplitterRatio = inputRatio
+        this.$nextTick(() => {
+          if (inputRatio < compactMidpoint) {
+            this.trueSplitterRatio = compactWidth
+            this.compact = true
+          } else if (inputRatio > compactMidpoint && inputRatio < compactCutoff) {
+            this.compact = false
+            this.trueSplitterRatio = compactCutoff
+          } else {
+            this.compact = false
+          }
+        })
+      }, 100)
+    }
   },
   created () {
     this.$q.dark.set(this.getDarkMode())

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -68,7 +68,7 @@ import { mapActions, mapGetters, mapState } from 'vuex'
 import { debounce } from 'quasar'
 
 const compactWidth = 70
-const compactCutoff = 250
+const compactCutoff = 325
 const compactMidpoint = (compactCutoff + compactWidth) / 2
 
 export default {


### PR DESCRIPTION
**Motivation**
Being able to switch your chat list to a more compact format allows you to see more of your screen. Currently pulling the chat list too small will result in a ugly mess of text cramped into a small space

**Implementation**
When the chat list is dragged into a sufficiently small column it snaps to a "compact mode" revealing only the display picture and a badge.