### PR TITLE
Add default groupchat contact

### DIFF
--- a/src/store/modules/chats.js
+++ b/src/store/modules/chats.js
@@ -6,6 +6,20 @@ import { desktopNotify } from '../../utils/notifications'
 
 const defaultContactObject = { inputMessage: '', lastRead: null, stampAmount: defaultStampAmount, totalUnreadMessages: 0, totalUnreadValue: 0, totalValue: 0 }
 
+const defaultChats = [
+  {
+    inputMessage: '',
+    lastRead: null,
+    stampAmount: 50000,
+    totalUnreadMessages: 0,
+    totalUnreadValue: 0,
+    totalValue: 0,
+    messages: {},
+    address: 'bchtest:qrugj9hv6lcar6hflk26yz8k9qq8wp9tvsmvvqqwgq',
+    lastReceived: null
+  }
+]
+
 function calculateUnreadAggregates (messages, lastReadTime) {
   const messageValues = messages
     .filter(message => !message.outbound)
@@ -33,6 +47,12 @@ export function rehydateChat (chatState) {
   chatState.messages = chatState.messages || {}
 
   if (chatState.chats) {
+    for (const chat of defaultChats) {
+      if (!(chat.address in chatState.chats)) {
+        chatState.chats[chat.address] = chat
+      }
+    }
+
     for (const contactAddress in chatState.chats) {
       const contact = chatState.chats[contactAddress]
       contact.address = contactAddress
@@ -56,7 +76,9 @@ export default {
   namespaced: true,
   state: {
     activeChatAddr: null,
-    chats: {},
+    chats: {
+
+    },
     messages: [],
     lastReceived: null
   },

--- a/src/store/modules/contacts.js
+++ b/src/store/modules/contacts.js
@@ -1,7 +1,7 @@
 import { PublicKey } from 'bitcore-lib-cash'
 import { getRelayClient } from '../../utils/relay-client-factory'
 import { addressColorFromStr } from '../../utils/formatting'
-import { defaultUpdateInterval, pendingRelayData } from '../../utils/constants'
+import { defaultUpdateInterval, pendingRelayData, defaultRelayUrl } from '../../utils/constants'
 import KeyserverHandler from '../../keyserver/handler'
 import Vue from 'vue'
 import moment from 'moment'
@@ -19,21 +19,52 @@ export default {
   namespaced: true,
   state: {
     contacts: {
-      // Example:
-      // 'qz5fqvs0xfp4p53hj0kk7v3h5t8qwx5pdcd7vv72zs': {
-      //   lastUpdate: ...
-      //   profile: {
-      //     name: 'Anon',
-      //     bio: '',
-      //     avatar: ...,
-      //     pubKey: ...,
-      //   },
-      //   inbox: {
-      //     acceptancePrice: ...,
-      //   },
-      //   notify: true,
-      //   relayURL: ...
-      // },
+      'bchtest:qrugj9hv6lcar6hflk26yz8k9qq8wp9tvsmvvqqwgq': {
+        lastUpdate: null,
+        profile: {
+          name: 'Stamp Group Chat #1',
+          pubKey: new Uint8Array([
+            2,
+            111,
+            154,
+            97,
+            51,
+            91,
+            21,
+            201,
+            249,
+            21,
+            64,
+            33,
+            209,
+            44,
+            71,
+            187,
+            52,
+            83,
+            161,
+            168,
+            20,
+            173,
+            139,
+            235,
+            85,
+            155,
+            234,
+            247,
+            223,
+            107,
+            31,
+            88,
+            32
+          ])
+        },
+        inbox: {
+          acceptancePrice: 5000
+        },
+        notify: true,
+        relayURL: defaultRelayUrl
+      }
     },
     updateInterval: defaultUpdateInterval
   },


### PR DESCRIPTION
This commit adds a default contact for the current StampChat bot.
It's not great, but it works. This should enable people to discover each
other at large -- hopefully. Iterative improvement.
