### PR TITLE
Fix tab rendering for the transaction dialog and add type info

### DIFF
--- a/src/components/chat/messages/ChatMessage.vue
+++ b/src/components/chat/messages/ChatMessage.vue
@@ -8,7 +8,7 @@
     <!-- Transaction Dialog -->
     <q-dialog v-model="transactionDialog">
       <!-- Switch to outpoints -->
-      <transaction-dialog title="Stamp Transaction" :outpoints="message.outpoints" />
+      <transaction-dialog title="Backing Transactions" :outpoints="message.outpoints" />
     </q-dialog>
 
     <!-- Delete Dialog -->

--- a/src/components/dialogs/TransactionDialog.vue
+++ b/src/components/dialogs/TransactionDialog.vue
@@ -6,21 +6,28 @@
     <q-card-section>
       <q-tabs
         v-if="outpoints.length !== 1"
-        v-model="outpoint"
+        v-model="tab"
         class="text-primary"
       >
         <q-tab v-for="n in outpoints.length"  :key="n" :name="n" :label="n"/>
       </q-tabs>
-      <q-tab-panel v-for="n in outpoints.length" :key="n" :name="n">
-        <q-item-section class='q-py-lg'>
-            <span class='text-bold'> Transaction ID </span>
-            <q-item-label>{{outpoints[n-1].txId}}</q-item-label>
-            <span class='text-bold'> Address </span>
-            {{ outpoints[n-1].address}}
-            <span class='text-bold'> Amount </span>
-            {{ outpoints[n-1].satoshis }}
-        </q-item-section>
-      </q-tab-panel>
+      <q-tab-panels
+        v-model="tab"
+        animated
+      >
+        <q-tab-panel v-for="n in outpoints.length" :key="n" :name="n">
+          <q-item-section class='q-py-lg'>
+              <span class='text-bold'> Transaction ID </span>
+              <q-item-label>{{outpoints[n-1].txId}}</q-item-label>
+              <span class='text-bold'> Type </span>
+              <q-item-label>{{outpoints[n-1].type}}</q-item-label>
+              <span class='text-bold'> Address </span>
+              {{ outpoints[n-1].address}}
+              <span class='text-bold'> Amount </span>
+              {{ outpoints[n-1].satoshis }}
+          </q-item-section>
+        </q-tab-panel>
+      </q-tab-panels>
     </q-card-section>
 
     <q-card-actions align="right">
@@ -41,7 +48,8 @@ export default {
   props: ['title', 'outpoints'],
   data () {
     return {
-      outpoint: 1
+      outpoint: 1,
+      tab: 1
     }
   },
   methods: {


### PR DESCRIPTION
Currently, the rendering of the tabs in this dialog is incorrect. It
does not have the `q-tab-panel` wrapped with the appropriate control,
and sharing a model with the `q-tabs` element. This commit fixes
that issue, as well as adding a type field and renaming the menu item.

The second two changes are because this dialog also shows other types
of outpoints attached to a message.