### PR TITLE
Fix a number of rendering errors caused by undefined data

### DIFF
--- a/src/components/chat/messages/Announcement.vue
+++ b/src/components/chat/messages/Announcement.vue
@@ -67,7 +67,7 @@ export default {
         case 'error':
           return ''
       }
-      return 'unknown'
+      return 'N/A'
     },
     timestampString () {
       const timestamp = this.lastMessage.timestamp || this.lastMessage.serverTime

--- a/src/components/chat/messages/ChatMessage.vue
+++ b/src/components/chat/messages/ChatMessage.vue
@@ -17,6 +17,7 @@
     </q-dialog>
 
     <chat-message-menu
+      v-if="message.payloadDigest"
       :address="address"
       :message="message"
       :payloadDigest="message.payloadDigest"
@@ -26,13 +27,16 @@
       @replyClick="replyClicked({ address, payloadDigest: message.payloadDigest })"
     />
 
-    <div class='col'>
-      <div class='q-px-lg' v-for="(item, index) in message.items" :key="index" >
+    <div class='col' v-if="message.payloadDigest">
+      <div  class='q-px-lg' v-for="(item, index) in message.items" :key="index" >
         <chat-message-reply v-if="item.type=='reply'" :payloadDigest="item.payloadDigest" :address="address" :mouseover="mouseover"/>
         <chat-message-text v-else-if="item.type=='text'" :text="item.text" />
         <chat-message-image v-else-if="item.type=='image'" :image="item.image" />
         <chat-message-stealth v-else-if="item.type=='stealth'" :amount="item.amount" />
       </div>
+    </div>
+    <div class='col' v-else-if="!message.payloadDigest">
+      unable to find message payload
     </div>
 
     <q-tooltip>
@@ -125,7 +129,7 @@ export default {
         case 'error':
           return ''
       }
-      return 'unknown'
+      return 'N/A'
     },
     shortTime () {
       switch (this.message.status) {
@@ -139,13 +143,16 @@ export default {
         case 'error':
           return ''
       }
-      return 'unknown'
+      return 'N/A'
     },
     timestampString () {
       const timestamp = this.message.timestamp || this.message.serverTime
       return moment(timestamp)
     },
     stampAmount () {
+      if (!this.message) {
+        return '0 sats'
+      }
       const amount = stampPrice(this.message.outpoints)
       return amount + ' sats'
     }

--- a/src/components/chat/messages/ChatMessageReply.vue
+++ b/src/components/chat/messages/ChatMessageReply.vue
@@ -12,6 +12,7 @@
 
 <script>
 import { mapGetters } from 'vuex'
+import { addressColorFromStr } from '../../../utils/formatting'
 
 export default {
   name: 'chat-message-reply',
@@ -47,17 +48,22 @@ export default {
       return message || { items: [] }
     },
     name () {
+      console.log('IsSame', this.message.senderAddress === this.$wallet.myAddressStr)
       if (this.message.senderAddress === this.$wallet.myAddressStr) {
         return this.getProfile.name
       }
       const contact = this.getContact()(this.message.senderAddress)
+      console.log('Not is Same', this.message.senderAddress, contact)
+      if (!contact) {
+        return 'Not Found'
+      }
       return contact.profile.name
     },
     nameColor () {
       if (this.message.senderAddress === this.$wallet.myAddressStr) {
         return 'text-black'
       }
-      return this.getContact()(this.address).color
+      return addressColorFromStr(this.address)
     }
   }
 }

--- a/src/pages/Chat.vue
+++ b/src/pages/Chat.vue
@@ -99,6 +99,7 @@ import ChatMessageStealth from '../components/chat/messages/ChatMessageStealth.v
 import SendBitcoinDialog from '../components/dialogs/SendBitcoinDialog.vue'
 import { donationMessage } from '../utils/constants'
 import { insufficientStampNotify } from '../utils/notifications'
+import { addressColorFromStr } from '../utils/formatting'
 
 const scrollDuration = 0
 
@@ -245,8 +246,7 @@ export default {
       return chunks
     },
     nameColor () {
-      const color = this.getContactVuex(this.address).color
-      return color
+      return addressColorFromStr(this.address)
     },
     ...mapGetters({
       getContactVuex: 'contacts/getContact',
@@ -285,9 +285,12 @@ export default {
       if (replyAddress === this.$wallet.myAddressStr) {
         return 'black'
       }
+      onsole.log('Hit', this.address, this.getContactVuex(this.address))
+
       return this.getContactVuex(this.address).color
     },
     contactProfile () {
+      console.log('Hit', this.address, this.getContactVuex(this.address))
       return this.getContactVuex(this.address).profile
     }
   },

--- a/src/store/modules/chats.js
+++ b/src/store/modules/chats.js
@@ -99,9 +99,8 @@ export default {
   state: {
     activeChatAddr: null,
     chats: {
-
     },
-    messages: [],
+    messages: {},
     lastReceived: null
   },
   getters: {


### PR DESCRIPTION
Sometimes, a reply message type includes an invalid message digest.
When that occurs, all kinds of rendering errors spew on the console.
This commit addresses those errors by ensuring that undefined data is
properly detected and overridden.