### PR TITLE
Remove name color generation from Vuex store. Generate on fly

### DIFF
--- a/src/pages/Chat.vue
+++ b/src/pages/Chat.vue
@@ -286,7 +286,7 @@ export default {
         return 'black'
       }
 
-      return this.getContactVuex(this.address).color
+      return this.addressColorFromStr(this.address)
     },
     contactProfile () {
       return this.getContactVuex(this.address).profile

--- a/src/store/modules/contacts.js
+++ b/src/store/modules/contacts.js
@@ -1,6 +1,5 @@
 import { PublicKey } from 'bitcore-lib-cash'
 import { getRelayClient } from '../../adapters/vuex-relay-adapter'
-import { addressColorFromStr } from '../../utils/formatting'
 import { defaultUpdateInterval, pendingRelayData, defaultRelayUrl } from '../../utils/constants'
 import KeyserverHandler from '../../keyserver/handler'
 import Vue from 'vue'
@@ -226,10 +225,7 @@ export default {
   },
   actions: {
     addLoadingContact ({ commit }, { address, pubKey }) {
-      /// Add color
-      const color = addressColorFromStr(address)
-
-      const contact = { ...pendingRelayData, profile: { ...pendingRelayData.profile, pubKey }, color }
+      const contact = { ...pendingRelayData, profile: { ...pendingRelayData.profile, pubKey } }
       commit('addContact', { address, contact })
     },
     deleteContact ({ commit }, address) {
@@ -238,9 +234,6 @@ export default {
       commit('deleteContact', address)
     },
     addContact ({ commit }, { address, contact }) {
-      /// Add color
-      contact.color = addressColorFromStr(address)
-
       commit('addContact', { address, contact })
       commit('chats/setActiveChat', address, { root: true })
     },


### PR DESCRIPTION
As per title. This simplifies some APIs and generally makes it easier
to avoid `undefined` results.
