### PR TITLE
Use level storage wrapper for saving messages 

### DIFF
--- a/src/adapters/level-message-store.ts
+++ b/src/adapters/level-message-store.ts
@@ -1,0 +1,6 @@
+import { LevelMessageStore } from '../relay/storage/level-storage'
+import { remote } from 'electron'
+const app = remote.app
+
+const appData = app.getPath('appData')
+export const store = new LevelMessageStore(appData)

--- a/src/adapters/vuex-relay-adapter.js
+++ b/src/adapters/vuex-relay-adapter.js
@@ -1,5 +1,6 @@
 import { RelayClient } from '../relay/client'
 import { defaultRelayUrl } from '../utils/constants'
+import { store as levelDbStore } from '../adapters/level-message-store'
 
 export function getRelayClient ({ wallet, electrumClient, store, relayUrl = defaultRelayUrl }) {
   const observables = { connected: false }
@@ -8,10 +9,7 @@ export function getRelayClient ({ wallet, electrumClient, store, relayUrl = defa
       const destPubKey = store.getters['contacts/getPubKey'](address)
       return destPubKey
     },
-    getStoredMessage: (paylgoadDiestHex) => {
-      const message = store.getters['chats/getMessageByPayload'](paylgoadDiestHex)
-      return message
-    }
+    messageStore: levelDbStore
   })
   client.events.on('disconnected', () => {
     observables.connected = false
@@ -27,11 +25,9 @@ export function getRelayClient ({ wallet, electrumClient, store, relayUrl = defa
     store.commit('chats/sendMessageLocal', { address, senderAddress, index, items, outpoints, transactions, retryData, status: 'error' })
   })
   client.events.on('messageSent', ({ address, senderAddress, index, items, outpoints, transactions }) => {
-    // TODO: Why no items here?
     store.commit('chats/sendMessageLocal', { address, senderAddress, index, items, outpoints, transactions, status: 'confirmed' })
   })
   client.events.on('receivedMessage', (args) => {
-    // TODO: Why no items here?
     store.dispatch('chats/receiveMessage', args)
   })
 

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -166,7 +166,7 @@ export default {
       this.$relayClient.setUpWebsocket(this.$wallet.myAddressStr)
       // const lastReceived = this.lastReceived
       const t0 = performance.now()
-      this.$relayClient.refresh({ lastReceived: null }).then(() => {
+      this.$relayClient.refresh().then(() => {
         const t1 = performance.now()
         console.log(`Loading messages took ${t1 - t0}ms`)
         this.$wallet.init()

--- a/src/relay/storage/level-storage.ts
+++ b/src/relay/storage/level-storage.ts
@@ -1,0 +1,189 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { MessageStore, MessageResult, MessageWrapper, MessageReturnResult } from './storage'
+import level from 'level'
+import { join } from 'path'
+
+const metadataKeys = {
+  schemaVersion: 'schemaVersion',
+  lastServerTime: 'lastServerTime'
+}
+
+class MessageIterator implements AsyncIterator<MessageWrapper> {
+  iterator: any;
+  db: any;
+
+  constructor (db: any) {
+    this.db = db
+  }
+
+  async next (): Promise<IteratorResult<MessageWrapper>> {
+    const value: MessageWrapper = await new Promise((resolve, reject) => {
+      this.iterator.next((error: Error, key: string, value: string) => {
+        if (error) {
+          reject(error)
+        }
+        if (!key) {
+          this.iterator.end((error: Error) => {
+            if (error) {
+              reject(error)
+            }
+            resolve()
+          })
+          resolve()
+          return
+        }
+        const parsedValue: MessageWrapper = JSON.parse(value)
+        resolve(parsedValue)
+      })
+    })
+    if (!value) {
+      return new MessageReturnResult()
+    }
+    return new MessageResult(value)
+  }
+
+  async return (): Promise<IteratorResult<MessageWrapper>> {
+    return new Promise((resolve, reject) => {
+      this.iterator.end((error: Error) => {
+        this.db.close()
+        if (error) {
+          reject(error)
+        }
+        resolve({ done: true, value: undefined })
+      })
+    })
+  }
+
+  [Symbol.asyncIterator] () {
+    this.iterator = this.db.iterator()
+    return this
+  }
+}
+
+const currentSchemaVersion = 1
+
+export class LevelMessageStore implements MessageStore {
+  private messageDbLocation: string
+  private metadataDbLocation: string
+  private schemaVersion?: number
+
+  constructor (location: string) {
+    this.messageDbLocation = join(location, 'messages')
+    this.metadataDbLocation = join(location, 'metadata')
+  }
+
+  private async getMessageDatabase () {
+    const db = level(this.messageDbLocation)
+    const dbSchemaVersion = await this.getSchemaVersion()
+    if (!dbSchemaVersion) {
+      await this.setSchemaVersion(currentSchemaVersion)
+    } else if (dbSchemaVersion < currentSchemaVersion) {
+      console.warn('Outdated DB, may need migration')
+    } else if (dbSchemaVersion > currentSchemaVersion) {
+      console.warn('Newer DB found. Client downgraded?')
+    }
+    return db
+  }
+
+  private getMetadataDatabase () {
+    return level(this.messageDbLocation)
+  }
+
+  async getMessage (payloadDigest: string): Promise<MessageWrapper | undefined> {
+    const db = await this.getMessageDatabase()
+    try {
+      const value = await db.get(payloadDigest)
+      return JSON.parse(value)
+    } catch (err) {
+      if (err.type === 'NotFoundError') {
+        return
+      }
+      throw err
+    } finally {
+      db.close()
+    }
+  }
+
+  async deleteMessage (payloadDigest: string) {
+    const db = await this.getMessageDatabase()
+    try {
+      await db.del(payloadDigest)
+    } finally {
+      db.close()
+    }
+  }
+
+  async saveMessage (message: MessageWrapper) {
+    const index = message.index
+    const db = await this.getMessageDatabase()
+    try {
+      await this.mostRecentMessageTime(message.newMsg.serverTime)
+      await db.put(index, JSON.stringify(message))
+    } finally {
+      db.close()
+    }
+  }
+
+  async mostRecentMessageTime (newLastServerTime: number): Promise<number> {
+    const db = await this.getMetadataDatabase()
+    try {
+      const lastServerTime: number = await db.get(metadataKeys.lastServerTime)
+      if (!lastServerTime) {
+        await db.put(metadataKeys.lastServerTime, newLastServerTime || 0)
+      }
+      if (!newLastServerTime) {
+        return lastServerTime
+      }
+      if (lastServerTime < newLastServerTime) {
+        await db.put(metadataKeys.lastServerTime, newLastServerTime)
+      }
+      return Math.max(newLastServerTime, lastServerTime)
+    } catch (err) {
+      if (err.type === 'NotFoundError') {
+        if (newLastServerTime) {
+          await db.put(metadataKeys.lastServerTime, newLastServerTime)
+          return newLastServerTime
+        }
+        return 0
+      }
+      throw err
+    } finally {
+      db.close()
+    }
+  }
+
+  private async getSchemaVersion (): Promise<number> {
+    if (this.schemaVersion) {
+      return this.schemaVersion
+    }
+
+    const db = await this.getMetadataDatabase()
+    try {
+      const value: number = await db.get(metadataKeys.schemaVersion)
+      return value
+    } catch (err) {
+      if (err.type === 'NotFoundError') {
+        return 0
+      }
+      throw err
+    } finally {
+      db.close()
+    }
+  }
+
+  private async setSchemaVersion (schemaVersion: number) {
+    const db = await this.getMetadataDatabase()
+    try {
+      await db.put(metadataKeys.schemaVersion, schemaVersion)
+      // Update cache
+      this.schemaVersion = schemaVersion
+    } finally {
+      db.close()
+    }
+  }
+
+  async getIterator (): Promise<AsyncIterator<MessageWrapper>> {
+    const db = await this.getMessageDatabase()
+    return new MessageIterator(db)
+  }
+}

--- a/src/relay/storage/storage.ts
+++ b/src/relay/storage/storage.ts
@@ -1,0 +1,65 @@
+
+import { PrivateKey } from 'bitcore-lib-cash'
+
+export interface Outpoint {
+  address: string;
+  privKey: PrivateKey; // This is okay, we don't add it to the wallet.
+  satoshis: number;
+  txId: string;
+  outputIndex: number;
+  type: string;
+}
+
+export interface Entry {
+  // Todo should match proto
+  type: string;
+  // Todo needs headers
+}
+
+export interface Message {
+  outbound: boolean;
+  status: string;
+  receivedTime: number;
+  serverTime: number;
+  items: Array<Entry>;
+  outpoints: Array<Outpoint>;
+  senderAddress: string;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface MessageWrapper {
+    newMsg: Message;
+    index: string;
+    outbound: boolean;
+    address: string;
+    senderAddress: string;
+    pubKey: string;
+}
+
+export class MessageResult implements IteratorYieldResult<MessageWrapper> {
+    done: false;
+    value: MessageWrapper;
+
+    constructor (value: MessageWrapper) {
+      this.done = false
+      this.value = value
+    }
+}
+
+export class MessageReturnResult implements IteratorReturnResult<MessageWrapper | undefined> {
+    done: true;
+    value: MessageWrapper | undefined;
+
+    constructor (value: MessageWrapper | undefined = undefined) {
+      this.done = true
+      this.value = value
+    }
+}
+
+export interface MessageStore {
+    getMessage(payloadDigest: string): Promise<MessageWrapper | undefined>;
+    saveMessage(message: MessageWrapper): void;
+    deleteMessage(payloadDigest: string): void;
+    mostRecentMessageTime (newLastServerTime: number): Promise<number>;
+    getIterator (): Promise<AsyncIterator<MessageWrapper>>;
+}

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -23,7 +23,7 @@ let lastSave = Date.now()
 const vuexLocal = new VuexPersistence({
   storage: window.localStorage,
   // Hack to allow us to easily rehydrate the store
-  restoreState: (key, storage) => {
+  restoreState: async (key, storage) => {
     const value = storage.getItem(key)
     let newState = parseState(value)
     console.log('Restoring state', newState)
@@ -50,7 +50,7 @@ const vuexLocal = new VuexPersistence({
     }
     console.log('new new state', newState)
     rehydrateContacts(newState.contacts)
-    rehydateChat(newState.chats, newState.contacts)
+    await rehydateChat(newState.chats, newState.contacts)
     rehydrateWallet(newState.wallet)
     return newState
   },
@@ -90,7 +90,8 @@ const vuexLocal = new VuexPersistence({
     lastSave = Date.now()
 
     return true
-  }
+  },
+  asyncStorage: true
 })
 
 export default new Vuex.Store({

--- a/src/types/bitcore-lib-cash/bitcore-lib-cash.d.ts
+++ b/src/types/bitcore-lib-cash/bitcore-lib-cash.d.ts
@@ -1,0 +1,309 @@
+declare module 'bitcore-lib-cash' {
+    // Type definitions for bitcore-lib 0.15
+    // Project: https://github.com/bitpay/bitcore-lib-cash
+    // Definitions by: Lautaro Dragan <https://github.com/lautarodragan>
+    // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+    export namespace crypto {
+        class BN { }
+
+        namespace ECDSA {
+            function sign(message: Buffer, key: PrivateKey): Signature;
+            function verify(hashbuf: Buffer, sig: Signature, pubkey: PublicKey, endian?: 'little'): boolean;
+        }
+
+        namespace Hash {
+            function sha1(buffer: Buffer): Buffer;
+            function sha256(buffer: Buffer): Buffer;
+            function sha256sha256(buffer: Buffer): Buffer;
+            function sha256ripemd160(buffer: Buffer): Buffer;
+            function sha512(buffer: Buffer): Buffer;
+            function ripemd160(buffer: Buffer): Buffer;
+
+            function sha256hmac(data: Buffer, key: Buffer): Buffer;
+            function sha512hmac(data: Buffer, key: Buffer): Buffer;
+        }
+
+        namespace Random {
+            function getRandomBuffer(size: number): Buffer;
+        }
+
+        namespace Point { }
+
+        class Signature {
+            static fromDER(sig: Buffer): Signature;
+            static fromString(data: string): Signature;
+            SIGHASH_ALL: number;
+            toString(): string;
+        }
+    }
+
+    export namespace Transaction {
+        class UnspentOutput {
+            static fromObject(o: object): UnspentOutput;
+
+            readonly address: Address;
+            readonly txId: string;
+            readonly outputIndex: number;
+            readonly script: Script;
+            readonly satoshis: number;
+
+            constructor(data: object);
+
+            inspect(): string;
+            toObject(): this;
+            toString(): string;
+        }
+
+        class Output {
+            readonly script: Script;
+            readonly satoshis: number;
+
+            constructor(data: object);
+
+            setScript(script: Script | string | Buffer): this;
+            inspect(): string;
+            toObject(): object;
+        }
+
+        class Input {
+            readonly prevTxId: Buffer;
+            readonly outputIndex: number;
+            readonly sequenceNumber: number;
+            readonly script: Script;
+            readonly output?: Output;
+        }
+    }
+
+    export class Transaction {
+        inputs: Transaction.Input[];
+        outputs: Transaction.Output[];
+        readonly id: string;
+        readonly hash: string;
+        nid: string;
+
+        constructor(serialized?: any);
+
+        from(utxos: Transaction.UnspentOutput[]): this;
+        to(address: Address[] | Address | string, amount: number): this;
+        change(address: Address | string): this;
+        fee(amount: number): this;
+        feePerKb(amount: number): this;
+        sign(privateKey: PrivateKey | string): this;
+        applySignature(sig: crypto.Signature): this;
+        addInput(input: Transaction.Input): this;
+        addOutput(output: Transaction.Output): this;
+        addData(value: Buffer): this;
+        lockUntilDate(time: Date | number): this;
+        lockUntilBlockHeight(height: number): this;
+
+        hasWitnesses(): boolean;
+        getFee(): number;
+        getChangeOutput(): Transaction.Output | null;
+        getLockTime(): Date | number;
+
+        verify(): string | boolean;
+        isCoinbase(): boolean;
+
+        enableRBF(): this;
+        isRBF(): boolean;
+
+        inspect(): string;
+        serialize(): string;
+    }
+
+    export class Block {
+        hash: string;
+        height: number;
+        transactions: Transaction[];
+        header: {
+            time: number;
+            prevHash: string;
+        };
+
+        constructor(data: Buffer | object);
+    }
+
+    export class PrivateKey {
+        readonly publicKey: PublicKey;
+        readonly network: Networks.Network;
+
+        toAddress(): Address;
+        toPublicKey(): PublicKey;
+        toString(): string;
+        toObject(): object;
+        toJSON(): object;
+        toWIF(): string;
+
+        constructor(key?: string, network?: Networks.Network);
+    }
+
+    export class PublicKey {
+        constructor(source: string);
+
+        static fromPrivateKey(privateKey: PrivateKey): PublicKey;
+
+        toBuffer(): Buffer;
+        toDER(): Buffer;
+    }
+
+    export class HDPrivateKey {
+        readonly hdPublicKey: HDPublicKey;
+
+        constructor(data?: string | Buffer | object);
+
+        derive(arg: string | number, hardened?: boolean): HDPrivateKey;
+        deriveChild(arg: string | number, hardened?: boolean): HDPrivateKey;
+        deriveNonCompliantChild(arg: string | number, hardened?: boolean): HDPrivateKey;
+
+        toString(): string;
+        toObject(): object;
+        toJSON(): object;
+    }
+
+    export class HDPublicKey {
+        readonly xpubkey: Buffer;
+        readonly network: Networks.Network;
+        readonly depth: number;
+        readonly publicKey: PublicKey;
+        readonly fingerPrint: Buffer;
+
+        constructor(arg: string | Buffer | object);
+
+        derive(arg: string | number, hardened?: boolean): HDPublicKey;
+        deriveChild(arg: string | number, hardened?: boolean): HDPublicKey;
+
+        toString(): string;
+    }
+
+    export namespace Script {
+        const types: {
+            DATA_OUT: string;
+        };
+        function buildMultisigOut(publicKeys: PublicKey[], threshold: number, opts: object): Script;
+        function buildWitnessMultisigOutFromScript(script: Script): Script;
+        function buildMultisigIn(pubkeys: PublicKey[], threshold: number, signatures: Buffer[], opts: object): Script;
+        function buildP2SHMultisigIn(pubkeys: PublicKey[], threshold: number, signatures: Buffer[], opts: object): Script;
+        function buildPublicKeyHashOut(address: Address): Script;
+        function buildPublicKeyOut(pubkey: PublicKey): Script;
+        function buildDataOut(data: string | Buffer, encoding?: string): Script;
+        function buildScriptHashOut(script: Script): Script;
+        function buildPublicKeyIn(signature: crypto.Signature | Buffer, sigtype: number): Script;
+        function buildPublicKeyHashIn(publicKey: PublicKey, signature: crypto.Signature | Buffer, sigtype: number): Script;
+
+        function fromAddress(address: string | Address): Script;
+
+        function empty(): Script;
+    }
+
+    export class Script {
+        constructor(data: string | object);
+
+        set(obj: object): this;
+
+        toBuffer(): Buffer;
+        toASM(): string;
+        toString(): string;
+        toHex(): string;
+
+        isPublicKeyHashOut(): boolean;
+        isPublicKeyHashIn(): boolean;
+
+        getPublicKey(): Buffer;
+        getPublicKeyHash(): Buffer;
+
+        isPublicKeyOut(): boolean;
+        isPublicKeyIn(): boolean;
+
+        isScriptHashOut(): boolean;
+        isWitnessScriptHashOut(): boolean;
+        isWitnessPublicKeyHashOut(): boolean;
+        isWitnessProgram(): boolean;
+        isScriptHashIn(): boolean;
+        isMultisigOut(): boolean;
+        isMultisigIn(): boolean;
+        isDataOut(): boolean;
+
+        getData(): Buffer;
+        isPushOnly(): boolean;
+
+        classify(): string;
+        classifyInput(): string;
+        classifyOutput(): string;
+
+        isStandard(): boolean;
+
+        prepend(obj: any): this;
+        add(obj: any): this;
+
+        hasCodeseparators(): boolean;
+        removeCodeseparators(): this;
+
+        equals(script: Script): boolean;
+
+        getAddressInfo(): Address | boolean;
+        findAndDelete(script: Script): this;
+        checkMinimalPush(i: number): boolean;
+        getSignatureOperationsCount(accurate: boolean): number;
+
+        toAddress(): Address;
+    }
+
+    export class Message {
+        constructor(message: string);
+
+        magicHash(): Buffer;
+        sign(privateKey: PrivateKey): string;
+        verify(bitcoinAddress: Address | string, signatureString: string): boolean;
+        fromString(str: string): Message;
+        fromJSON(json: string): Message;
+        toObject(): { message: string };
+        toJSON(): string;
+        toString(): string;
+        inspect(): string;
+    }
+
+    export interface Util {
+        readonly buffer: {
+            reverse(a: any): any;
+        };
+    }
+
+    export namespace Networks {
+        interface Network {
+            readonly name: string;
+            readonly alias: string;
+        }
+
+        const livenet: Network;
+        const mainnet: Network;
+        const testnet: Network;
+
+        function add(data: any): Network;
+        function remove(network: Network): void;
+        function get(args: string | number | Network, keys: string | string[]): Network;
+    }
+
+    export class Address {
+        readonly hashBuffer: Buffer;
+        readonly network: Networks.Network;
+        readonly type: string;
+
+        constructor(data: Buffer | Uint8Array | string | object, network?: Networks.Network, type?: string);
+    }
+
+    export class Unit {
+        static fromBTC(amount: number): Unit;
+        static fromMilis(amount: number): Unit;
+        static fromBits(amount: number): Unit;
+        static fromSatoshis(amount: number): Unit;
+
+        constructor(amount: number, unitPreference: string);
+
+        toBTC(): number;
+        toMilis(): number;
+        toBits(): number;
+        toSatoshis(): number;
+    }
+
+}

--- a/src/types/level/level.d.ts
+++ b/src/types/level/level.d.ts
@@ -1,0 +1,1 @@
+declare module 'level';

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -7,14 +7,6 @@ export const electrumServers = [
   {
     electrumURL: 'electroncash.de',
     electrumPort: 50_004
-  },
-  {
-    electrumURL: 'fulcrum-testnet.bchjs.cash',
-    electrumPort: 50_002
-  },
-  {
-    electrumURL: 'blackie.c3-soft.com',
-    electrumPort: 60_002
   }
 ]
 export const electrumPingInterval = 10_000


### PR DESCRIPTION
Previously, we used the Vuex-persistence store for messages. However,
this uses a single localstorage key for storing all data as one
serialized JSON blob. The limitations of this caused undefined behavior
after a certain amount of messages were received. Thus, we are switching
to manual storage against leveldb/indexdb. This wrapper allows us to
implement once, and have support in both node and electron/browsers.

Node support is important as we also want to use these as libraries in
the future to enable people to write bots and other headless wallets.