### PR TITLE
Address issues with reconnect logic on load

### DIFF
--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -164,18 +164,29 @@ export default {
     // Setup everything at once. This are independent processes
     try {
       this.$relayClient.setUpWebsocket(this.$wallet.myAddressStr)
-      // const lastReceived = this.lastReceived
-      const t0 = performance.now()
+    } catch (err) {
+      console.error(err)
+    }
+
+    // const lastReceived = this.lastReceived
+    const t0 = performance.now()
+    const refreshMessages = () => {
+      // Wait for a connected electrum client
+      if (!this.$electrum.connected) {
+        setTimeout(refreshMessages, 100)
+      }
       this.$relayClient.refresh().then(() => {
         const t1 = performance.now()
         console.log(`Loading messages took ${t1 - t0}ms`)
         this.$wallet.init()
-        console.log('loaded')
+        console.log('Wallet initialized')
         this.loaded = true
+      }).catch((err) => {
+        console.error(err)
+        setTimeout(refreshMessages, 100)
       })
-    } catch (err) {
-      console.error(err)
     }
+    refreshMessages()
   },
   mounted () {
     document.addEventListener('keydown', this.shortcutKeyListener)

--- a/src/pages/Setup.vue
+++ b/src/pages/Setup.vue
@@ -65,8 +65,8 @@
             <q-btn
               @click="next()"
               color="primary"
-              :label="forwardLabel()"
-              :disable="forwardDisabled()"
+              :label="forwardLabel"
+              :disable="forwardDisabled"
             />
             <q-btn
               v-if="step > 1"
@@ -121,6 +121,7 @@ export default {
   },
   data () {
     return {
+      forwardDisabled: false,
       step: 1,
       name: '',
       bio: '',
@@ -445,38 +446,6 @@ export default {
           this.nextSettings()
       }
     },
-    forwardLabel () {
-      switch (this.step) {
-        case 1:
-          return 'Continue'
-        case 2:
-          return (this.seedData.type === 'new') ? 'New Wallet' : 'Import Wallet'
-        case 3:
-          return 'Continue'
-        case 4:
-          return 'Continue'
-        case 5:
-          return this.isBasic ? 'Finish' : 'Continue'
-        case 6:
-          return 'Finish'
-      }
-    },
-    forwardDisabled () {
-      // Cannot progress while electrum is disconnected
-      if (!this.electrumConnected) {
-        return true
-      }
-
-      switch (this.step) {
-        case 2:
-          return !this.isWalletValid
-        case 5:
-          return !this.isRelayValid
-        case 6:
-          return (this.settings === null)
-      }
-      return false
-    },
     previous () {
       switch (this.step) {
         case 4:
@@ -495,17 +464,50 @@ export default {
       } else if (newValue && this.step === 6) {
         this.step = 5
       }
+    },
+    '$electrumClient.connected' () {
+      if (!this.$electrum.connected) {
+        this.forwardDisabled = true
+      }
+
+      switch (this.step) {
+        case 2:
+          this.forwardDisabled = !this.isWalletValid
+          break
+        case 5:
+          this.forwardDisabled = !this.isRelayValid
+          break
+        case 6:
+          this.forwardDisabled = (this.settings === null)
+          break
+        default:
+          this.forwardDisabled = false
+      }
     }
   },
   computed: {
-    electrumConnected () {
-      return this.$electrum.connected
-    },
     isWalletValid () {
       return ((this.seedData.type === 'new') || (this.seedData.type === 'import' && this.seedData.valid))
     },
     isRelayValid () {
       return !!(this.relayData.profile.name && this.relayData.profile.avatar && this.relayData.inbox.acceptancePrice)
+    },
+    forwardLabel () {
+      switch (this.step) {
+        case 1:
+          return 'Continue'
+        case 2:
+          return (this.seedData.type === 'new') ? 'New Wallet' : 'Import Wallet'
+        case 3:
+          return 'Continue'
+        case 4:
+          return 'Continue'
+        case 5:
+          return this.isBasic ? 'Finish' : 'Continue'
+        case 6:
+          return 'Finish'
+      }
+      return 'Unknown'
     }
   },
   created () {

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,12 +1,28 @@
 // Electrum constants
 export const electrumServers = [
   {
-    electrumURL: 'testnet.bitcoincash.network',
+    electrumURL: 'bch0.kister.net',
+    electrumPort: 51_002
+  },
+  {
+    electrumURL: 'blackie.c3-soft.com',
     electrumPort: 60_002
   },
   {
     electrumURL: 'electroncash.de',
     electrumPort: 50_004
+  },
+  {
+    electrumURL: 'tbch.loping.net',
+    electrumPort: 60_002
+  },
+  {
+    electrumURL: 'testnet.bitcoincash.network',
+    electrumPort: 60_002
+  },
+  {
+    electrumURL: 'testnet.imaginary.cash',
+    electrumPort: 50_002
   }
 ]
 export const electrumPingInterval = 10_000


### PR DESCRIPTION
The electrum-cash `client.connect` method never resolves its promise
when connections fail. Thus the setup prior to MainLayout loading was
never succeeding if the first attempted Electrum server was offline.
This commit removes the `await` and updates downstream logic to properly
handle the need to reconnect to the electrum server immediately at
startup.