### PR TITLE
Move UTXO storage to leveldb

### DIFF
--- a/src/adapters/level-outpoint-store.ts
+++ b/src/adapters/level-outpoint-store.ts
@@ -1,0 +1,6 @@
+import { LevelOutpointStore } from '../wallet/storage/level-storage'
+import { remote } from 'electron'
+const app = remote.app
+
+const appData = app.getPath('appData')
+export const store = new LevelOutpointStore(appData)

--- a/src/boot/setup-apis.js
+++ b/src/boot/setup-apis.js
@@ -3,6 +3,7 @@ import { Client as ElectrumClient } from 'electrum-cash'
 import { electrumPingInterval, electrumServers, defaultRelayUrl } from '../utils/constants'
 import { Wallet } from '../wallet'
 import { getRelayClient } from '../adapters/vuex-relay-adapter'
+import { store as levelDbOutpointStore } from '../adapters/level-outpoint-store'
 
 function instrumentElectrumClient ({ client, observables, reconnector }) {
   const keepAlive = () => {
@@ -64,27 +65,31 @@ function createAndBindNewElectrumClient ({ Vue, observables, wallet }) {
 }
 
 function getWalletClient ({ store }) {
+  // FIXME: This shouldn't be necessary, but the GUI needs real time
+  // balance updates. In the future, we should just aggregate a total over time here.
   const storageAdapter = {
-    getFrozenUTXOs () {
-      return store.getters['wallet/getFrozenUTXOs']
+    getOutpoint (id) {
+      return levelDbOutpointStore.getOutpoint(id)
     },
-    freezeUTXO (id) {
-      store.commit('wallet/freezeUTXO', id)
-    },
-    unfreezeUTXO (id) {
-      store.commit('wallet/unfreezeUTXO', id)
-    },
-    removeFrozenUTXO (id) {
-      store.commit('wallet/removeFrozenUTXO', id)
-    },
-    getUTXOs () {
-      return store.getters['wallet/getUTXOs']
-    },
-    removeUTXO (id) {
+    deleteOutpoint (id) {
       store.commit('wallet/removeUTXO', id)
+      return levelDbOutpointStore.deleteOutpoint(id)
     },
-    addUTXO (output) {
-      store.commit('wallet/addUTXO', output)
+    putOutpoint (outpoint) {
+      store.commit('wallet/addUTXO', outpoint)
+      return levelDbOutpointStore.putOutpoint(outpoint)
+    },
+    freezeOutpoint (id) {
+      return levelDbOutpointStore.freezeOutpoint(id)
+    },
+    unfreezeOutpoint (id) {
+      return levelDbOutpointStore.unfreezeOutpoint(id)
+    },
+    getOutpointIterator () {
+      return levelDbOutpointStore.getOutpointIterator()
+    },
+    getFrozenOutpointIterator () {
+      return levelDbOutpointStore.getFrozenOutpointIterator()
     }
   }
 

--- a/src/components/chat/ChatList.vue
+++ b/src/components/chat/ChatList.vue
@@ -44,7 +44,7 @@
       <q-item v-show="!compact" clickable @click="walletOpen=true">
         <q-item-section>
           <q-item-label>Balance</q-item-label>
-          <q-item-label caption>{{ getBalance }}</q-item-label>
+          <q-item-label caption>{{ formattedBalance }}</q-item-label>
         </q-item-section>
         <q-item-section v-if="!walletConnected" side>
           <q-btn icon="account_balance_wallet" flat round color="red" />
@@ -103,7 +103,8 @@ export default {
   computed: {
     ...mapGetters({
       getSortedChatOrder: 'chats/getSortedChatOrder',
-      getNumUnread: 'chats/getNumUnread'
+      getNumUnread: 'chats/getNumUnread',
+      balance: 'wallet/balance'
     }),
     relayConnected () {
       return this.$relay.connected
@@ -111,8 +112,8 @@ export default {
     walletConnected () {
       return this.$electrum.connected
     },
-    getBalance () {
-      return formatBalance(this.$wallet.balance)
+    formattedBalance () {
+      return formatBalance(this.balance)
     }
   }
 }

--- a/src/components/context_menus/ChatMessageMenu.vue
+++ b/src/components/context_menus/ChatMessageMenu.vue
@@ -88,18 +88,18 @@ export default {
       getStampAmount: 'chats/getStampAmount'
     }),
     sendMessage (...args) {
-      this.$relayClient.sendMessage(args)
+      return this.$relayClient.sendMessage(args)
     },
     sendStealthPayment (...args) {
-      this.$relayClient.sendStealthPayment(args)
+      return this.$relayClient.sendStealthPayment(args)
     },
     sendImage (...args) {
-      this.$relayClient.sendImage(args)
+      return this.$relayClient.sendImage(args)
     },
     resend () {
       this.deleteMessage({ address: this.address, payloadDigest: this.payloadDigest, index: this.index })
       const stampAmount = this.getStampAmount()(this.address)
-      this.$relayClient.sendMessageImpl({ address: this.address, items: this.message.items, stampAmount })
+      return this.$relayClient.sendMessageImpl({ address: this.address, items: this.message.items, stampAmount })
     },
     copyMessage () {
       const text = this.message.items.find(el => el.type === 'text').text

--- a/src/components/dialogs/SendAddressDialog.vue
+++ b/src/components/dialogs/SendAddressDialog.vue
@@ -80,7 +80,7 @@ export default {
           satoshis: this.amount
         })
 
-        const { transaction, usedIDs } = this.$wallet.constructTransaction({ outputs: [output], exactOutputs: true })
+        const { transaction, usedIDs } = await this.$wallet.constructTransaction({ outputs: [output], exactOutputs: true })
         const txHex = transaction.toString()
 
         try {

--- a/src/components/dialogs/WalletDialog.vue
+++ b/src/components/dialogs/WalletDialog.vue
@@ -12,7 +12,7 @@
       <div class="text-h6">Wallet Status</div>
     </q-card-section>
     <q-card-section>
-      <div class="text-bold text-subtitle1 text-center"> {{getBalance}}</div>
+      <div class="text-bold text-subtitle1 text-center"> {{formattedBalance}}</div>
     </q-card-section>
     <q-separator />
     <q-card-section>
@@ -91,9 +91,10 @@ export default {
   },
   computed: {
     ...mapGetters({
+      balance: 'wallet/balance'
     }),
-    getBalance () {
-      return formatBalance(this.$wallet.balance)
+    formattedBalance () {
+      return formatBalance(this.balance)
     }
   },
   methods: {

--- a/src/components/setup/DepositStep.vue
+++ b/src/components/setup/DepositStep.vue
@@ -91,6 +91,7 @@
 <script>
 import QrcodeVue from 'qrcode.vue'
 import { copyToClipboard } from 'quasar'
+import { mapGetters } from 'vuex'
 import { numAddresses, recomendedBalance } from '../../utils/constants'
 import { addressCopiedNotify } from '../../utils/notifications'
 import { formatBalance } from '../../utils/formatting'
@@ -123,9 +124,6 @@ export default {
       const privKey = this.$wallet.privKeys[this.paymentAddrCounter]
       this.currentAddress = privKey.toAddress('testnet').toString() // TODO: Make generic
     },
-    getBalance () {
-      return this.$wallet.balance
-    },
     openFaucet () {
       const shell = require('electron').shell
       event.preventDefault()
@@ -136,12 +134,13 @@ export default {
     }
   },
   computed: {
+    ...mapGetters({ balance: 'wallet/balance' }),
     percentageBalance () {
-      const percentage = 100 * Math.min(this.getBalance() / this.recomendedBalance, 1)
+      const percentage = 100 * Math.min(this.balance / this.recomendedBalance, 1)
       return percentage
     },
     formatBalance () {
-      return formatBalance(this.getBalance())
+      return formatBalance(this.balance)
     }
   }
 }

--- a/src/pages/Setup.vue
+++ b/src/pages/Setup.vue
@@ -324,7 +324,7 @@ export default {
         })
 
         // Construct payment
-        const { paymentUrl, payment } = pop.constructPaymentTransaction(this.$wallet, paymentDetails)
+        const { paymentUrl, payment } = await pop.constructPaymentTransaction(this.$wallet, paymentDetails)
         const { token } = await pop.sendPayment(paymentUrl, payment)
 
         // Construct metadata
@@ -377,7 +377,7 @@ export default {
         })
 
         // Get token from relay server
-        const { paymentUrl, payment } = pop.constructPaymentTransaction(this.$wallet, relayPaymentRequest.paymentDetails)
+        const { paymentUrl, payment } = await pop.constructPaymentTransaction(this.$wallet, relayPaymentRequest.paymentDetails)
         const { token } = await relayClient.sendPayment(paymentUrl, payment)
         relayClient.setToken(token)
         this.setRelayToken(token)

--- a/src/pop/index.js
+++ b/src/pop/index.js
@@ -39,7 +39,7 @@ export default {
     return { paymentReceipt, token }
   },
 
-  constructPaymentTransaction (wallet, paymentDetails) {
+  async constructPaymentTransaction (wallet, paymentDetails) {
     // Get Outputs
     const requestOutputs = paymentDetails.getOutputsList()
     const outputs = requestOutputs.map(reqOutput => {
@@ -53,7 +53,7 @@ export default {
     })
 
     // Construct tx
-    const { transaction, usedIDs } = wallet.constructTransaction({ outputs, exactOutputs: true })
+    const { transaction, usedIDs } = await wallet.constructTransaction({ outputs, exactOutputs: true })
     const rawTransaction = transaction.toBuffer()
 
     // Send payment and receive token

--- a/src/relay/constructors.js
+++ b/src/relay/constructors.js
@@ -55,11 +55,10 @@ export const constructStealthTransactions = function (wallet, ephemeralPrivKey, 
   }
 
   // Construct transaction
-  const transactionBundle = wallet.constructTransactionSet({ addressGenerator: stealthPubKeyGenerator, amount })
-  return transactionBundle
+  return wallet.constructTransactionSet({ addressGenerator: stealthPubKeyGenerator, amount })
 }
 
-export const constructMessage = function (wallet, serializedPayload, privKey, destPubKey, stampAmount) {
+export const constructMessage = async function (wallet, serializedPayload, privKey, destPubKey, stampAmount) {
   const payloadDigest = cashlib.crypto.Hash.sha256(serializedPayload)
   const ecdsa = cashlib.crypto.ECDSA({ privkey: privKey, hashbuf: payloadDigest })
   ecdsa.sign()
@@ -71,7 +70,7 @@ export const constructMessage = function (wallet, serializedPayload, privKey, de
   message.setSignature(sig)
   message.setSerializedPayload(serializedPayload)
 
-  const transactionBundle = constructStampTransactions(wallet, payloadDigest, destPubKey, stampAmount)
+  const transactionBundle = await constructStampTransactions(wallet, payloadDigest, destPubKey, stampAmount)
 
   for (const { transaction: stampTx, vouts } of transactionBundle) {
     const rawStampTx = stampTx.toBuffer()
@@ -143,7 +142,7 @@ export const constructTextEntry = function ({ text }) {
   return textEntry
 }
 
-export const constructStealthEntry = function ({ wallet, amount, destPubKey }) {
+export const constructStealthEntry = async function ({ wallet, amount, destPubKey }) {
   // Construct payment entry
   const paymentEntry = new messaging.Entry()
   paymentEntry.setKind('stealth-payment')
@@ -151,7 +150,7 @@ export const constructStealthEntry = function ({ wallet, amount, destPubKey }) {
   const stealthPaymentEntry = new stealth.StealthPaymentEntry()
   const ephemeralPrivKey = cashlib.PrivateKey()
 
-  const transactionBundle = constructStealthTransactions(wallet, ephemeralPrivKey, destPubKey, amount)
+  const transactionBundle = await constructStealthTransactions(wallet, ephemeralPrivKey, destPubKey, amount)
 
   // Sent to HASH160(ephemeralPrivKey * destPubKey)
   // Sent to HASH160(ephemeralPrivKey * destPubKey)

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -30,7 +30,10 @@ const vuexLocal = new VuexPersistence({
     if (newState.version !== STORE_SCHEMA_VERSION) {
       // Import everything else from the server again
       newState = {
-        wallet: newState.wallet,
+        wallet: {
+          xPrivKey: path(['wallet', 'xPrivKey'], newState),
+          seedPhrase: path(['wallet', 'seedPhrase'], newState)
+        },
         relayClient: {
           token: path(['relayClient', 'token'], newState)
         },
@@ -51,13 +54,16 @@ const vuexLocal = new VuexPersistence({
     console.log('new new state', newState)
     rehydrateContacts(newState.contacts)
     await rehydateChat(newState.chats, newState.contacts)
-    rehydrateWallet(newState.wallet)
+    await rehydrateWallet(newState.wallet)
     return newState
   },
   reducer (state) {
     console.log('reducing state', state)
     return {
-      wallet: state.wallet,
+      wallet: {
+        xPrivKey: path(['wallet', 'xPrivKey'], state),
+        seedPhrase: path(['wallet', 'seedPhrase'], state)
+      },
       relayClient: {
         token: path(['relayClient', 'token'], state)
       },

--- a/src/wallet/helpers.js
+++ b/src/wallet/helpers.js
@@ -1,5 +1,8 @@
 export const calcId = function (output) {
-  return output.txId.slice(0, 20) + output.outputIndex
+  if (!output.txId === undefined || !output.outputIndex === undefined) {
+    throw new Error(`Missing values ${JSON.stringify(output)}`)
+  }
+  return output.txId + '_' + output.outputIndex
 }
 
 export const stampPrice = function (outpoints) {

--- a/src/wallet/storage/level-storage.ts
+++ b/src/wallet/storage/level-storage.ts
@@ -1,0 +1,190 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import level from 'level'
+import { join } from 'path'
+
+import { OutpointStore, OutpointResult, Outpoint, OutpointReturnResult, OutpointId } from './storage'
+import { calcId } from '../helpers'
+
+const metadataKeys = {
+  schemaVersion: 'schemaVersion',
+  lastServerTime: 'lastServerTime'
+}
+
+class OutpointIterator implements AsyncIterator<Outpoint> {
+  iterator: any;
+  db: any;
+  onlyFrozen: boolean
+
+  constructor (db: any, onlyFrozen = false) {
+    this.db = db
+    this.onlyFrozen = onlyFrozen
+  }
+
+  async next (): Promise<IteratorResult<Outpoint>> {
+    const value: Outpoint = await new Promise((resolve, reject) => {
+      this.iterator.next((error: Error, key: string, value: string) => {
+        if (error) {
+          reject(error)
+        }
+        if (!key) {
+          this.iterator.end((error: Error) => {
+            if (error) {
+              reject(error)
+            }
+            resolve()
+          })
+          resolve()
+          return
+        }
+        const parsedOutpoint: Outpoint = JSON.parse(value)
+        resolve(parsedOutpoint)
+      })
+    })
+    if (this.onlyFrozen && value.frozen) {
+      return this.next()
+    }
+    if (!value) {
+      return new OutpointReturnResult()
+    }
+    return new OutpointResult(value)
+  }
+
+  async return (): Promise<IteratorResult<Outpoint>> {
+    return new Promise((resolve, reject) => {
+      this.iterator.end((error: Error) => {
+        this.db.close()
+        if (error) {
+          reject(error)
+        }
+        resolve({ done: true, value: undefined })
+      })
+    })
+  }
+
+  [Symbol.asyncIterator] () {
+    this.iterator = this.db.iterator()
+    return this
+  }
+}
+
+const currentSchemaVersion = 1
+
+export class LevelOutpointStore implements OutpointStore {
+  private outpointDbLocation: string
+  private metadataDbLocation: string
+  private schemaVersion?: number
+
+  constructor (location: string) {
+    this.outpointDbLocation = join(location, 'outpoints')
+    this.metadataDbLocation = join(location, 'metadata')
+  }
+
+  private async getOutpointDatabase () {
+    const db = level(this.outpointDbLocation)
+    const dbSchemaVersion = await this.getSchemaVersion()
+    if (!dbSchemaVersion) {
+      await this.setSchemaVersion(currentSchemaVersion)
+    } else if (dbSchemaVersion < currentSchemaVersion) {
+      console.warn('Outdated DB, may need migration')
+    } else if (dbSchemaVersion > currentSchemaVersion) {
+      console.warn('Newer DB found. Client downgraded?')
+    }
+    return db
+  }
+
+  private getMetadataDatabase () {
+    return level(this.metadataDbLocation)
+  }
+
+  async getOutpoint (id: OutpointId): Promise<Outpoint | undefined> {
+    const db = await this.getOutpointDatabase()
+    try {
+      const value = await db.get(id)
+      return JSON.parse(value)
+    } catch (err) {
+      if (err.type === 'NotFoundError') {
+        return
+      }
+      throw err
+    } finally {
+      db.close()
+    }
+  }
+
+  async deleteOutpoint (id: OutpointId) {
+    const db = await this.getOutpointDatabase()
+    try {
+      await db.del(id)
+    } finally {
+      db.close()
+    }
+  }
+
+  async putOutpoint (outpoint: Outpoint) {
+    const index = calcId(outpoint)
+    const db = await this.getOutpointDatabase()
+    try {
+      await db.put(index, JSON.stringify(outpoint))
+    } finally {
+      db.close()
+    }
+  }
+
+  async freezeOutpoint (outpointId: OutpointId) {
+    const outpoint = await this.getOutpoint(outpointId)
+    if (outpoint === undefined) {
+      throw Error('missing key')
+    }
+    outpoint.frozen = true
+    await this.putOutpoint(outpoint)
+  }
+
+  async unfreezeOutpoint (outpointId: OutpointId) {
+    const outpoint = await this.getOutpoint(outpointId)
+    if (outpoint === undefined) {
+      throw Error('missing key')
+    }
+    outpoint.frozen = false
+    await this.putOutpoint(outpoint)
+  }
+
+  private async getSchemaVersion (): Promise<number> {
+    if (this.schemaVersion) {
+      return this.schemaVersion
+    }
+
+    const db = await this.getMetadataDatabase()
+    try {
+      const value: number = await db.get(metadataKeys.schemaVersion)
+      return value
+    } catch (err) {
+      if (err.type === 'NotFoundError') {
+        return 0
+      }
+      throw err
+    } finally {
+      db.close()
+    }
+  }
+
+  private async setSchemaVersion (schemaVersion: number) {
+    const db = await this.getMetadataDatabase()
+    try {
+      await db.put(metadataKeys.schemaVersion, schemaVersion)
+      // Update cache
+      this.schemaVersion = schemaVersion
+    } finally {
+      db.close()
+    }
+  }
+
+  async getOutpointIterator (): Promise<AsyncIterator<Outpoint>> {
+    const db = await this.getOutpointDatabase()
+    return new OutpointIterator(db)
+  }
+
+  async getFrozenOutpointIterator (): Promise<AsyncIterator<Outpoint>> {
+    const db = await this.getOutpointDatabase()
+    return new OutpointIterator(db, true)
+  }
+}

--- a/src/wallet/storage/storage.ts
+++ b/src/wallet/storage/storage.ts
@@ -1,0 +1,41 @@
+import { PrivateKey } from 'bitcore-lib-cash'
+
+export interface Outpoint {
+  address: string;
+  privKey: PrivateKey; // This is okay, we don't add it to the wallet.
+  satoshis: number;
+  txId: string;
+  outputIndex: number;
+  type: string;
+  frozen: boolean | undefined;
+}
+
+export type OutpointId = string
+
+export class OutpointResult implements IteratorYieldResult<Outpoint> {
+  done: false;
+  value: Outpoint;
+
+  constructor (value: Outpoint) {
+    this.done = false
+    this.value = value
+  }
+}
+
+export class OutpointReturnResult implements IteratorReturnResult<Outpoint | undefined> {
+  done: true;
+  value: Outpoint | undefined;
+
+  constructor (value: Outpoint | undefined = undefined) {
+    this.done = true
+    this.value = value
+  }
+}
+
+export interface OutpointStore {
+  getOutpoint(id: OutpointId): Promise<Outpoint | undefined>;
+  deleteOutpoint(id: OutpointId): void;
+  putOutpoint(outpoint: Outpoint): void;
+  getOutpointIterator(): Promise<AsyncIterator<Outpoint>>;
+  getFrozenOutpointIterator(): Promise<AsyncIterator<Outpoint>>;
+}


### PR DESCRIPTION
In order to further enable headless bots, we need to move away from Vuex
for anything that is non-GUI. This commit adds an outpoint store for
the wallet that uses leveldb directly instead of Vuex-persistence.
