### PR TITLE
Ensure sending message updates read time

### DIFF
--- a/src/store/modules/chats.js
+++ b/src/store/modules/chats.js
@@ -282,6 +282,7 @@ export default {
       state.messages[index] = message
       if (address in state.chats) {
         state.chats[address].messages.push(message)
+        state.chats[address].lastRead = Date.now()
         return
       }
       Vue.set(state.chats, address, { ...defaultContactObject, messages: [message], address })


### PR DESCRIPTION
Ensure last read time is updated when sending a message. This ensures
that when reloading from disk that the last few outbound messages do
not show up as unread.
