### PR TITLE
Fix race conditions introduced when enabling async store

### DIFF
--- a/src/boot/setup-apis.js
+++ b/src/boot/setup-apis.js
@@ -92,6 +92,7 @@ function getWalletClient ({ store }) {
 }
 
 export default async ({ store, Vue }) => {
+  await store.restored
   // TODO: WE should probably rename this file to something more specific
   // as its instantiating the wallet now also.
   const wallet = getWalletClient({ store })
@@ -102,7 +103,7 @@ export default async ({ store, Vue }) => {
   if (xPrivKey) {
     console.log('Loaded previous private key')
     wallet.setXPrivKey(xPrivKey)
-    await wallet.init()
+    // await wallet.init()
   }
   const { client: relayClient, observables: relayObservables } = getRelayClient({ relayUrl: defaultRelayUrl, wallet, electrumObservables, store })
   const relayToken = store.getters['relayClient/getToken']

--- a/src/router/routes.ts
+++ b/src/router/routes.ts
@@ -1,9 +1,11 @@
 import { RouteConfig, Route } from 'vue-router'
 import store from '../store/index'
 
-function redirectIfNoProfile (to: Route, from: Route, next: (route?: string) => void) {
-  const name = store.getters['myProfile/getProfile'].name
-  if (name) {
+async function redirectIfNoProfile (to: Route, from: Route, next: (route?: string) => void) {
+  // eslint-disable-next-line dot-notation
+  await store['restored']
+  const profile = store.getters['myProfile/getProfile']
+  if (profile.name) {
     next()
   } else {
     next('/setup')

--- a/src/store/modules/chats.js
+++ b/src/store/modules/chats.js
@@ -100,7 +100,7 @@ export async function rehydateChat (chatState) {
     if (!messageWrapper.newMsg) {
       continue
     }
-    const { index, newMsg, address } = messageWrapper
+    const { index, newMsg, copartyAddress } = messageWrapper
     assert(newMsg.outbound !== undefined)
     assert(newMsg.status !== undefined)
     assert(newMsg.receivedTime !== undefined)
@@ -113,19 +113,19 @@ export async function rehydateChat (chatState) {
     if (!chatState.messages) {
       chatState.messages = {}
     }
-    if (!chatState.chats[address]) {
-      chatState.chats[address] = { ...defaultContactObject, messages: [], address }
+    if (!chatState.chats[copartyAddress]) {
+      chatState.chats[copartyAddress] = { ...defaultContactObject, messages: [], copartyAddress }
     }
     chatState.messages[index] = message
-    chatState.chats[address].messages.push(message)
-    chatState.chats[address].lastReceived = message.serverTime
+    chatState.chats[copartyAddress].messages.push(message)
+    chatState.chats[copartyAddress].lastReceived = message.serverTime
     const messageValue = stampPrice(message.outpoints) + message.items.reduce((totalValue, { amount = 0 }) => totalValue + amount, 0)
-    if (address !== chatState.activeChatAddr && chatState.chats[address].lastRead < message.serverTime) {
-      chatState.chats[address].totalUnreadValue += messageValue
-      chatState.chats[address].totalUnreadMessages += 1
+    if (copartyAddress !== chatState.activeChatAddr && chatState.chats[copartyAddress].lastRead < message.serverTime) {
+      chatState.chats[copartyAddress].totalUnreadValue += messageValue
+      chatState.chats[copartyAddress].totalUnreadMessages += 1
     }
     chatState.lastReceived = message.serverTime
-    chatState.chats[address].totalValue += messageValue
+    chatState.chats[copartyAddress].totalValue += messageValue
   }
 
   // Resort chats


### PR DESCRIPTION
Due to the previous conversation to leveldb for storing messages, some
other problems were introduced upon loading. These center around the
store possibly not being fully loaded before launching other components.
This commit either ensures certain initalization steps only happen after
the electrum client, and the store, are fully loaded.
