### PR TITLE
Fix more reconnect issues in the wallet

### DIFF
--- a/src/boot/setup-apis.js
+++ b/src/boot/setup-apis.js
@@ -4,7 +4,19 @@ import { electrumPingInterval, electrumServers, defaultRelayUrl } from '../utils
 import { Wallet } from '../wallet'
 import { getRelayClient } from '../adapters/vuex-relay-adapter'
 
-function instrumentElectrumClient ({ client, observables, reconnector }) {
+function instrumentElectrumClient ({ Vue, wallet, client, observables, reconnector }) {
+  // We need a local variable that is unique to this client, so it doesn't fuck around
+  let connectionAlive = false
+  const notifyDisconnect = () => {
+    // Don't reset connected state if we've already
+    if (!connectionAlive) {
+      return
+    }
+    connectionAlive = false
+    console.log('electrum disconnected')
+    observables.connected = false
+  }
+
   const keepAlive = () => {
     setTimeout(() =>
       client.request('server_ping')
@@ -19,25 +31,28 @@ function instrumentElectrumClient ({ client, observables, reconnector }) {
           }
         ).catch(err => {
           console.error('Error pinging electrum server. Likely disconnected', err)
-          observables.connected = false
+          notifyDisconnect()
         })
     , electrumPingInterval)
   }
 
   client.connection.socket.on('connect', () => {
     console.log('electrum connected')
+    // (Re)set state on Vue prototype
+    Vue.prototype.$electrumClient = client
+    wallet.setElectrumClient(client)
+    connectionAlive = true
     observables.connected = true
     keepAlive()
   })
 
   client.connection.socket.on('close', () => {
-    console.log('electrum disconnected')
-    observables.connected = false
+    notifyDisconnect()
     reconnector()
   })
 
   client.connection.socket.on('end', (e) => {
-    observables.connected = false
+    notifyDisconnect()
     console.log(e)
   })
 
@@ -54,13 +69,12 @@ function createAndBindNewElectrumClient ({ Vue, observables, wallet }) {
   console.log('Using electrum server:', electrumURL, electrumPort)
   const client = new ElectrumClient('Stamp Wallet', '1.4.1', electrumURL, electrumPort)
   instrumentElectrumClient({
+    Vue,
     client,
     observables,
+    wallet,
     reconnector: () => createAndBindNewElectrumClient({ Vue, observables, wallet })
   })
-  // (Re)set state on Vue prototype
-  Vue.prototype.$electrumClient = client
-  wallet.setElectrumClient(client)
 }
 
 function getWalletClient ({ store }) {

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -174,6 +174,7 @@ export default {
       // Wait for a connected electrum client
       if (!this.$electrum.connected) {
         setTimeout(refreshMessages, 100)
+        return
       }
       this.$relayClient.refresh().then(() => {
         const t1 = performance.now()

--- a/src/wallet/index.js
+++ b/src/wallet/index.js
@@ -56,6 +56,8 @@ export class Wallet {
 
   setElectrumClient (client) {
     this.electrumClient = client
+    this.initAddresses()
+    this.startListeners()
   }
 
   setXPrivKey (xPrivKey) {


### PR DESCRIPTION
1. Retry of calling wallet refresh did not properly terminate
   when `setTimeout` was called.
2. Due to multiple events being fired on close, sometimes a new
   connection would be started before the last close event on the
   electrum client. This commit ensures that the connected observable
   is only set once, so that the UI is consistent with the connection
   state.