### PR TITLE
Fix settings dialog width

### DIFF
--- a/src/components/dialogs/SettingsDialog.vue
+++ b/src/components/dialogs/SettingsDialog.vue
@@ -1,5 +1,8 @@
 <template>
-  <q-card>
+  <q-card
+    style="width: 500px"
+    class="q-px-sm q-pb-md"
+  >
     <q-card-section>
       <div class="text-h6">Settings</div>
     </q-card-section>


### PR DESCRIPTION
**Motivation**
Prior to this the settings dialog would switch width based on which tab was open.