### PR TITLE
Replace electrumClient with a promise to a client

### DIFF
--- a/src/components/dialogs/SendAddressDialog.vue
+++ b/src/components/dialogs/SendAddressDialog.vue
@@ -84,7 +84,7 @@ export default {
         const txHex = transaction.toString()
 
         try {
-          const electrumHandler = this.$electrumClient
+          const electrumHandler = await this.$electrumClientPromise
           await electrumHandler.request('blockchain.transaction.broadcast', txHex)
           sentTransactionNotify()
           console.log('Sent transaction', txHex)

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -128,8 +128,7 @@ export default {
     ...mapState('chats', ['chats', 'activeChatAddr']),
     ...mapGetters({
       getContact: 'contacts/getContact',
-      lastReceived: 'chats/getLastReceived',
-      totalUnread: 'chats/totalUnread'
+      lastReceived: 'chats/getLastReceived'
     }),
     splitterRatio: {
       get: function () {
@@ -180,8 +179,6 @@ export default {
       this.$relayClient.refresh().then(() => {
         const t1 = performance.now()
         console.log(`Loading messages took ${t1 - t0}ms`)
-        this.$wallet.init()
-        console.log('Wallet initialized')
         this.loaded = true
       }).catch((err) => {
         console.error(err)
@@ -195,12 +192,6 @@ export default {
   },
   beforeDestroy () {
     document.removeEventListener('keydown', this.shortcutKeyListener)
-  },
-  watch: {
-    totalUnread: function (unread) {
-      const { app } = window.require('electron').remote
-      app.setBadgeCount(unread)
-    }
   }
 }
 </script>

--- a/src/pages/Setup.vue
+++ b/src/pages/Setup.vue
@@ -200,14 +200,6 @@ export default {
           message: 'Watching wallet...'
         })
 
-        // Listen to addresses
-        try {
-          await this.$wallet.init()
-        } catch (err) {
-          errorNotify(err)
-          return
-        }
-
         // Check for existing metadata
         this.$q.loading.show({
           delay: 100,
@@ -296,7 +288,7 @@ export default {
       // Get profile from relay server
       // We do this first to prevent uploading broken URL to keyserver
       const idAddress = this.$wallet.myAddress
-      const { client: relayClient } = getRelayClient({ relayUrl: this.relayUrl, store: this.$store, electrumClient: this.$electrumClient, wallet: this.$wallet })
+      const { client: relayClient } = getRelayClient({ relayUrl: this.relayUrl, store: this.$store, wallet: this.$wallet })
 
       try {
         this.relayData = await relayClient.getRelayData(idAddress)
@@ -359,7 +351,7 @@ export default {
       }
     },
     async setupRelay () {
-      const { client: relayClient } = getRelayClient({ relayUrl: this.relayUrl, store: this.$store, electrumClient: this.$electrumClient, wallet: this.$wallet })
+      const { client: relayClient } = getRelayClient({ relayUrl: this.relayUrl, store: this.$store, electrumClientPromise: this.$electrumClientPromise, wallet: this.$wallet })
 
       // Set filter
       this.$q.loading.show({
@@ -465,7 +457,7 @@ export default {
         this.step = 5
       }
     },
-    '$electrumClient.connected' () {
+    '$electrum.connected' () {
       if (!this.$electrum.connected) {
         this.forwardDisabled = true
       }


### PR DESCRIPTION
Currently, we set the electrumClient field in a variety of places once
as soon as the client has been created. However, this means that we may
attempt to make requests before connection is completed. This commit
changes the system to provide a promise to a client, which gets resolved
or rejected, when the client has actually connected. This ensures that
the client is ready before making requests, and that init() is
properly called in the wallet every time the electrumClient is restarted
