### PR TITLE
Attempt to add windows badge icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "bluebird": "^3.7.2",
     "core-js": "^3.6.5",
     "dompurify": "^2.0.11",
+    "electron-windows-badge": "^1.0.5",
     "electrum-cash": "^1.0.1",
     "emoji-mart-vue-fast": "^7.0.2",
     "google-protobuf": "^3.12.0-rc.1",

--- a/src-electron/main-process/electron-main.js
+++ b/src-electron/main-process/electron-main.js
@@ -1,6 +1,7 @@
 import { app, BrowserWindow, nativeTheme, Tray, Menu, shell, nativeImage } from 'electron'
 import path from 'path'
 import fs from 'fs'
+import Badge from 'electron-windows-badge'
 
 // Enable single instance lock
 const isSingleInstance = app.requestSingleInstanceLock()
@@ -30,6 +31,7 @@ function getIconPNGPath () {
 
 let mainWindow
 let tray
+let windowsBadgeUpdater
 const nativeIcon = nativeImage.createFromPath(getIconPNGPath()).resize({ width: 16, height: 16 })
 
 function createWindow () {
@@ -61,6 +63,8 @@ function createWindow () {
       nodeIntegrationInWorker: process.env.QUASAR_NODE_INTEGRATION
     }
   })
+
+  windowsBadgeUpdater = new Badge(mainWindow, {})
 
   mainWindow.loadURL(process.env.APP_URL)
 

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -69,6 +69,7 @@ import ContactPanel from '../components/panels/ContactPanel.vue'
 import ContactBookDialog from '../components/dialogs/ContactBookDialog.vue'
 import { mapActions, mapGetters, mapState } from 'vuex'
 import { debounce } from 'quasar'
+import { remote, ipcRenderer } from 'electron'
 
 const compactWidth = 70
 const compactCutoff = 325
@@ -196,8 +197,8 @@ export default {
   },
   watch: {
     totalUnread: function (unread) {
-      const { app } = window.require('electron').remote
-      app.setBadgeCount(unread)
+      ipcRenderer.sendSync('update-badge', 1)
+      remote.app.setBadgeCount(unread)
     }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4602,6 +4602,11 @@ electron-to-chromium@^1.3.488:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.496.tgz#3f43d32930481d82ad3663d79658e7c59a58af0b"
   integrity sha512-TXY4mwoyowwi4Lsrq9vcTUYBThyc1b2hXaTZI13p8/FRhY2CTaq5lK+DVjhYkKiTLsKt569Xes+0J5JsVXFurQ==
 
+electron-windows-badge@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/electron-windows-badge/-/electron-windows-badge-1.0.5.tgz#22d8d9be626812f45918cce568665eb4928cb601"
+  integrity sha512-khEdgNmszS8+xZwQkTmcpqG3NCIuooryDF760T95zcC1CB5YeBBGhhmKGVcyQkWKTeZ4RXcyqqXbmjesTfeU5A==
+
 electron@^9.0.0:
   version "9.1.0"
   resolved "https://registry.yarnpkg.com/electron/-/electron-9.1.0.tgz#ca77600c9e4cd591298c340e013384114d3d8d05"


### PR DESCRIPTION
This commit adds the electron-windows-badge package in an attempt to
support badge icons on windows. This does not fix Tray icons under
MacOS, or linux, unfortunately.
