### PR TITLE
Ensure constructTransaction[Set] does not reuse UTXOs

### DIFF
--- a/src/wallet/index.js
+++ b/src/wallet/index.js
@@ -435,9 +435,9 @@ export class Wallet {
       }
       amountLeft -= amountToUse
       usedUtxos.push(...stagedUtxos)
-      stagedUtxos.map(
+      await Promise.all(stagedUtxos.map(
         utxo => this.storage.freezeOutpoint(calcId(utxo))
-      )
+      ))
       this.finalizeTransaction({ transaction, signingKeys })
       transactionBundle.push({
         transaction,
@@ -468,6 +468,9 @@ export class Wallet {
     const utxos = []
 
     for await (const utxo of outpointIterator) {
+      if (utxo.frozen) {
+        continue
+      }
       utxos.push(utxo)
     }
 
@@ -515,9 +518,9 @@ export class Wallet {
       throw Error('insufficient funds')
     }
 
-    usedUtxos.map(
+    await Promise.all(usedUtxos.map(
       utxo => this.storage.freezeOutpoint(calcId(utxo))
-    )
+    ))
 
     // Add change outputs using our HD wallet.  We want multiple outputs following a
     // power distribution, so we don't have to combine lots of outputs at later times


### PR DESCRIPTION
Currently, we are not properly awaiting freezeUTXO which would hyptoth-
etically allow a frozen UTXO to be selected again before it froze.
Additionally, constructTransaction was not properly filtering out frozen
UTXOs from construction. This meant that early on in the setup process
(and possibly ather places) you could not generate two of the same
output-size transactions back-to-back before the wallet was updated from
the electrum subscriptions.
