### PR TITLE
Fix lit error around unused variable

### DIFF
--- a/src-electron/main-process/electron-main.js
+++ b/src-electron/main-process/electron-main.js
@@ -31,6 +31,7 @@ function getIconPNGPath () {
 
 let mainWindow
 let tray
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 let windowsBadgeUpdater
 const nativeIcon = nativeImage.createFromPath(getIconPNGPath()).resize({ width: 16, height: 16 })
 


### PR DESCRIPTION
This variable needs to be able to be set, even if it is unused. It hangs
around and receives events in the rendering thread for updating the
window badge overlays.
