### PR TITLE
Remove persistence from dialogs

### DIFF
--- a/src/components/panels/ContactPanel.vue
+++ b/src/components/panels/ContactPanel.vue
@@ -1,10 +1,7 @@
 <template>
   <div class="column full-height">
     <!-- Send Bitcoin dialog -->
-    <q-dialog
-      v-model="sendBitcoinOpen"
-      persistent
-    >
+    <q-dialog v-model="sendBitcoinOpen">
       <send-bitcoin-dialog
         :address="address"
         :contact="contact.profile"
@@ -12,10 +9,7 @@
     </q-dialog>
 
     <!-- Clear history dialog -->
-    <q-dialog
-      v-model="confirmClearOpen"
-      persistent
-    >
+    <q-dialog v-model="confirmClearOpen">
       <clear-history-dialog
         :address="address"
         :name="contact.profile.name"
@@ -23,10 +17,7 @@
     </q-dialog>
 
     <!-- Delete chat dialog -->
-    <q-dialog
-      v-model="confirmDeleteOpen"
-      persistent
-    >
+    <q-dialog v-model="confirmDeleteOpen">
       <delete-chat-dialog
         :address="address"
         :name="contact.profile.name"

--- a/src/pages/Chat.vue
+++ b/src/pages/Chat.vue
@@ -7,18 +7,12 @@
   >
     <!-- Send file dialog -->
     <!-- TODO: Move this up.  We don't need a copy of this dialog for each address (likely) -->
-    <q-dialog
-      v-model="sendFileOpen"
-      persistent
-    >
+    <q-dialog v-model="sendFileOpen">
       <send-file-dialog :address="address" />
     </q-dialog>
 
     <!-- Send money dialog -->
-    <q-dialog
-      v-model="sendMoneyOpen"
-      persistent
-    >
+    <q-dialog v-model="sendMoneyOpen">
       <send-bitcoin-dialog
         :address="address"
         :contact="contactProfile"


### PR DESCRIPTION
**Motivation**
Many dialogs were previously marked as `persistent`, preventing them from being exited via the escape key.

Fixes https://github.com/cashweb/stamp/issues/235