### PR TITLE
Fix keyboard navigation of contacts

### DIFF
--- a/src/components/contacts/ContactList.vue
+++ b/src/components/contacts/ContactList.vue
@@ -42,16 +42,22 @@ export default {
         this.activeAddress = addresses[this.nextAddressIndex({ direction: 1 })]
       }
       if (e.key === 'Enter') {
+        e.preventDefault()
         this.contactClick(this.activeAddress, this.contacts[this.activeAddress])
-        this.$emit('close-contact-search-dialog')
       }
     },
     nextAddressIndex ({ direction }) {
       const addresses = Object.keys(this.contacts)
+      // Add addresses.length so that not found (-1) is the last item
       return (addresses.indexOf(this.activeAddress) + direction + addresses.length) % addresses.length
     },
     navigateUsingMouse (addressToBecomeFocused) {
       this.activeAddress = addressToBecomeFocused
+    }
+  },
+  watch: {
+    contacts () {
+      this.activeAddress = Object.keys(this.contacts)[0]
     }
   }
 }

--- a/src/components/dialogs/ContactBookDialog.vue
+++ b/src/components/dialogs/ContactBookDialog.vue
@@ -32,8 +32,7 @@
     <q-card-section class="q-pb-none">
       <contact-list
         :contacts="searchContacts(search)"
-        :contactClick="contactClick"
-        @close-contact-search-dialog="closeContactSearchDialog"
+        :contact-click="contactClick"
       />
     </q-card-section>
     <q-card-actions align="right">
@@ -53,14 +52,36 @@ import NewContactDialog from '../dialogs/NewContactDialog.vue'
 import { mapGetters } from 'vuex'
 
 export default {
-  props: ['contactClick'],
+  props: {
+    contactClick: {
+      type: Function,
+      required: true
+    }
+  },
   components: {
     ContactList,
     NewContactDialog
   },
+  methods: {
+    searchContacts (searchPrefix) {
+      const sortedContacts = Object.entries(this.contacts).sort((e1, e2) => {
+        return e1[0] < e2[0]
+      })
+
+      const result = {}
+      for (const [address, contact] of sortedContacts) {
+        const lowerSearch = searchPrefix.toLowerCase()
+        if (contact.profile.name.toLowerCase().includes(lowerSearch) || address.toLowerCase().includes(lowerSearch)) {
+          result[address] = contact
+        }
+      }
+
+      return result
+    }
+  },
   computed: {
     ...mapGetters({
-      searchContacts: 'contacts/searchContacts'
+      contacts: 'contacts/getContacts'
     })
   },
   data () {
@@ -71,11 +92,6 @@ export default {
   },
   mounted () {
     this.$refs.contactSearch.$el.focus()
-  },
-  methods: {
-    closeContactSearchDialog () {
-      this.$emit('close-contact-search-dialog')
-    }
   }
 }
 </script>

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -22,7 +22,7 @@
       />
     </q-drawer>
     <q-dialog v-model="contactBookOpen">
-      <contact-book-dialog :contactClick="function (address, contact) { return setActiveChat(address) }"/>
+      <contact-book-dialog :contact-click="contactClicked" />
     </q-dialog>
     <q-page-container>
       <q-page :style-fn="tweak">
@@ -125,6 +125,11 @@ export default {
       if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
         this.toggleContactBookOpen()
       }
+    },
+    contactClicked (address) {
+      this.contactBookOpen = false
+
+      return this.setActiveChat(address)
     }
   },
   computed: {

--- a/src/store/modules/contacts.js
+++ b/src/store/modules/contacts.js
@@ -36,6 +36,9 @@ export default {
     getContact: (state) => (address) => {
       return state.contacts[address] ? state.contacts[address] : { ...pendingRelayData, profile: { ...pendingRelayData.profile } }
     },
+    getContacts: (state) => {
+      return state.contacts
+    },
     getContactProfile: (state) => (address) => {
       return state.contacts[address] ? state.contacts[address].profile : { ...pendingRelayData.profile }
     },
@@ -48,18 +51,6 @@ export default {
       }
       const arr = Uint8Array.from(Object.values(state.contacts[address].profile.pubKey))
       return PublicKey.fromBuffer(arr)
-    },
-    searchContacts: (state) => (search) => {
-      const result = {}
-      const contacts = state.contacts
-      for (const key in contacts) {
-        const lowerSearch = search.toLowerCase()
-        if (contacts[key].profile.name.toLowerCase().includes(lowerSearch) || key.toLowerCase().includes(lowerSearch)) {
-          result[key] = contacts[key]
-        }
-      }
-
-      return result
     }
   },
   mutations: {


### PR DESCRIPTION
A previous commit enabled the contact search dialog to be opened with
Cmd-K. However, there were some oddities in the behavior when pressing
enter, or having accidentally had an address which was not part of the
search results. This commit removes some complexity, and adds the
necessary watchers to make sure that the address is always defined.

Fixes #221, #225, #287