### PR TITLE
Fix serialization format of BCH Addresses

### DIFF
--- a/src/relay/client.js
+++ b/src/relay/client.js
@@ -646,7 +646,7 @@ export class RelayClient {
             stealthValue += satoshis
 
             const stampOutput = {
-              address,
+              address: address.toLegacyAddress(),
               satoshis,
               outputIndex,
               privKey: outpointPrivKey,


### PR DESCRIPTION
Due to the way we are now serializing and de-serializing addresses, we
need to ensure we do not depend on Bitcore types directly. This commit
fixes the one place where we were still serializing Bitcore Address
objects and stringifies it into a Base58 address. This ensures that
the UTXOs can be used later without rehydrating.
