### PR TITLE
Ensure event listener in contact dialog is unregistered

### DIFF
--- a/src/components/contacts/ContactList.vue
+++ b/src/components/contacts/ContactList.vue
@@ -29,8 +29,11 @@ export default {
       activeAddress: Object.keys(this.contacts)[0]
     }
   },
-  mounted () {
+  created () {
     document.addEventListener('keydown', this.navigateUsingArrowKeys)
+  },
+  beforeDestroy () {
+    document.removeEventListener('keydown', this.navigateUsingArrowKeys)
   },
   methods: {
     navigateUsingArrowKeys (e) {


### PR DESCRIPTION
Currently, each time the contact search dialog is opened, a keydown
listener is registered, but never unregistered. This causes various
actions to fire later when entering messages into the chat input.
Generally, it is unnoticed, but it can cause strange issues where the
active chat switches after pressing enter. This commit ensures the event
handlers are unregistered when the dialog is closed.