### PR TITLE
Ensure only one transaction is being constructed at a time

### DIFF
--- a/src/wallet/lock.js
+++ b/src/wallet/lock.js
@@ -1,0 +1,39 @@
+import { EventEmitter } from 'events'
+
+// This file is graciously lifted from http://thecodebarbarian.com/mutual-exclusion-patterns-with-node-promises.html
+// and is presumably in the public domain.
+
+export class Lock {
+  constructor () {
+    this._locked = false
+    this._ee = new EventEmitter()
+  }
+
+  acquire () {
+    return new Promise(resolve => {
+      // If nobody has the lock, take it and resolve immediately
+      if (!this._locked) {
+        // Safe because JS doesn't interrupt you on synchronous operations,
+        // so no need for compare-and-swap or anything like that.
+        this._locked = true
+        return resolve()
+      }
+
+      // Otherwise, wait until somebody releases the lock and try again
+      const tryAcquire = () => {
+        if (!this._locked) {
+          this._locked = true
+          this._ee.removeListener('release', tryAcquire)
+          return resolve()
+        }
+      }
+      this._ee.on('release', tryAcquire)
+    })
+  }
+
+  release () {
+    // Release the lock immediately
+    this._locked = false
+    setImmediate(() => this._ee.emit('release'))
+  }
+}


### PR DESCRIPTION
Since we added leveldb support for storing UTXOs, constructTransanction*
is no longer synchronous. This means multiple transactions can be
constructed at the same time, possibly attempting to use the same UTXOs.
As a result, things which send transactions quickly (like bots) are
rather broken. This commit addresses that issue by adding a simple
lock around the construct transaction function. Future work should make
this more clean upstream.
