### PR TITLE
Do not open/close leveldb repeatedly

### DIFF
--- a/src/adapters/level-outpoint-store.ts
+++ b/src/adapters/level-outpoint-store.ts
@@ -1,6 +1,13 @@
 import { LevelOutpointStore } from '../wallet/storage/level-storage'
 import { remote } from 'electron'
-const app = remote.app
+import process from 'process'
 
+const app = remote.app
 const appData = app.getPath('appData')
+
 export const store = new LevelOutpointStore(appData)
+
+store.Open()
+process.on('exit', (/* code */) => {
+  store.Close()
+})


### PR DESCRIPTION
Leveldb does various checks and cleaning when it is opened and closed.
This creates unnecessary overhead every time we want to get or set a
key. As such, this slows transaction generation considerably. This
commit removes that process and ensures the db is gracefully closed when
possible.

Part of fixing #298