### PR TITLE
Fix frozen outpoint iterators

### DIFF
--- a/src/components/dialogs/SendAddressDialog.vue
+++ b/src/components/dialogs/SendAddressDialog.vue
@@ -87,6 +87,8 @@ export default {
           await electrumHandler.request('blockchain.transaction.broadcast', txHex)
           sentTransactionNotify()
           console.log('Sent transaction', txHex)
+          // TODO: we shouldn't be dealing with this here. Leaky abstraction
+          await Promise.all(usedIDs.map(id => wallet.storage.deleteOutpoint(id)))
         } catch (err) {
           usedIDs.forEach(id => {
             this.$wallet.unfreezeUTXO(id)

--- a/src/relay/client.js
+++ b/src/relay/client.js
@@ -332,7 +332,11 @@ export class RelayClient {
         return electrumClient.request('blockchain.transaction.broadcast', transaction.toString())
       }))
         .then(() => this.pushMessages(destinationAddress, messageSet))
-        .then(() => this.events.emit('messageSent', { address, senderAddress, index: payloadDigestHex, items, outpoints, transactions }))
+        .then(async () => {
+          this.events.emit('messageSent', { address, senderAddress, index: payloadDigestHex, items, outpoints, transactions })
+          // TODO: we shouldn't be dealing with this here. Leaky abstraction
+          await Promise.all(usedIDs.map(id => wallet.storage.deleteOutpoint(id)))
+        })
         .catch(async (err) => {
           console.error(err)
           if (err.response) {

--- a/src/wallet/storage/level-storage.ts
+++ b/src/wallet/storage/level-storage.ts
@@ -40,12 +40,16 @@ class OutpointIterator implements AsyncIterator<Outpoint> {
         resolve(parsedOutpoint)
       })
     })
-    if (this.onlyFrozen && value.frozen) {
-      return this.next()
-    }
     if (!value) {
       return new OutpointReturnResult()
     }
+    if (!this.onlyFrozen && value.frozen) {
+      return this.next()
+    }
+    if (this.onlyFrozen && !value.frozen) {
+      return this.next()
+    }
+
     return new OutpointResult(value)
   }
 
@@ -177,7 +181,7 @@ export class LevelOutpointStore implements OutpointStore {
   }
 
   async getOutpointIterator (): Promise<AsyncIterator<Outpoint>> {
-    return new OutpointIterator(this.db)
+    return new OutpointIterator(this.db, false)
   }
 
   async getFrozenOutpointIterator (): Promise<AsyncIterator<Outpoint>> {


### PR DESCRIPTION
Currently, our outpoint iterators erroneously include frozen UTXOs. This
commit removes them from being returned by the iterators, and ensures
that they are eventually fixed/deleted.
