### PR TITLE
Use the appropriate search function in javascript

### DIFF
--- a/src/wallet/index.js
+++ b/src/wallet/index.js
@@ -448,8 +448,8 @@ export class Wallet {
           usedIds: stagedUtxos.map(utxo => calcId(utxo))
         })
         // Remove used UTXOs
-        for (const utxo in stagedUtxos) {
-          const index = sortedUtxos.find((availableUtxo) => {
+        for (const utxo of stagedUtxos) {
+          const index = sortedUtxos.findIndex((availableUtxo) => {
             return calcId(utxo) !== calcId(availableUtxo)
           })
           if (index === -1) {


### PR DESCRIPTION
We need an index to use `Array.prototype.splice` with. Currently, we're
using `find`. This commit fixes it via `findIndex`. Yay typeless
languages.
