### PR TITLE
Remove unreliable electrum server

### DIFF
--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -16,10 +16,10 @@ export const electrumServers = [
     electrumURL: 'tbch.loping.net',
     electrumPort: 60_002
   },
-  {
-    electrumURL: 'testnet.bitcoincash.network',
-    electrumPort: 60_002
-  },
+  // {
+  //   electrumURL: 'testnet.bitcoincash.network',
+  //   electrumPort: 60_002
+  // },
   {
     electrumURL: 'testnet.imaginary.cash',
     electrumPort: 50_002


### PR DESCRIPTION
This electrum server does not drop connections, but insteads holds them
open despite doing nothing. This breaks the reconnect logic and also
prevents any messages from being sent.