### PR TITLE
Fix the wallet storage class type

### DIFF
--- a/src/wallet/storage/storage.ts
+++ b/src/wallet/storage/storage.ts
@@ -34,8 +34,11 @@ export class OutpointReturnResult implements IteratorReturnResult<Outpoint | und
 
 export interface OutpointStore {
   getOutpoint(id: OutpointId): Promise<Outpoint | undefined>;
-  deleteOutpoint(id: OutpointId): void;
-  putOutpoint(outpoint: Outpoint): void;
+  deleteOutpoint(id: OutpointId): Promise<void>;
+  putOutpoint(outpoint: Outpoint): Promise<void>;
+  freezeOutpoint (outpointId: OutpointId): Promise<void>
+  unfreezeOutpoint (outpointId: OutpointId): Promise<void>
+
   getOutpointIterator(): Promise<AsyncIterator<Outpoint>>;
   getFrozenOutpointIterator(): Promise<AsyncIterator<Outpoint>>;
 }


### PR DESCRIPTION
This should have been an issue sooner, but we're only using these type-
script classes from within TypeScript at the moment.
