### PR TITLE
Ensure we attempt to use sufficiently sized UTXOs first

### DIFF
--- a/src/wallet/index.js
+++ b/src/wallet/index.js
@@ -326,7 +326,10 @@ export class Wallet {
       let satoshis = 0
       const stagedUtxos = []
       while (true) {
-        const utxoToUse = pickOne(utxos)
+        const requisiteSize = amountLeft + (transaction._estimateSize() + 2 * standardUtxoSize + standardInputSize + minimumOutputAmount) * feePerByte
+        const biggerUtxos = utxos.filter((a) => a.satoshis >= requisiteSize)
+        const utxoSetToUse = biggerUtxos.length !== 0 ? biggerUtxos : utxos
+        const utxoToUse = pickOne(utxoSetToUse)
         stagedUtxos.push(utxoToUse)
         utxoToUse.script = Script.buildPublicKeyHashOut(utxoToUse.address).toHex()
         transaction.from(utxoToUse)


### PR DESCRIPTION
Because we now split transaction bundles into a set number of fragments,
it is better to now try to use a random UTXO that is bigger than
whatever amount was determined to be used. This ensures we don't try
to create 1-input -> 1-output transactions for no particular reason.
Doing so would waste users funds on fees.
