### PR TITLE
increase stamp price input width, add price

### DIFF
--- a/src/components/chat/ChatInput.vue
+++ b/src/components/chat/ChatInput.vue
@@ -52,8 +52,8 @@
       <q-input
         dense
         outlined
-        style="width: 125px"
-        label="Stamp"
+        style="width: 150px"
+        label="Stamp Price"
         suffix="sats"
         :value="stampAmount"
         @input="stampAmountChanged"


### PR DESCRIPTION
I thought this looks a little better
<img width="678" alt="Screen Shot 2020-08-09 at 12 27 02 PM" src="https://user-images.githubusercontent.com/833712/89740244-e3eb5d80-da3b-11ea-84ae-b3cde2d99530.png">
<img width="641" alt="Screen Shot 2020-08-09 at 12 26 53 PM" src="https://user-images.githubusercontent.com/833712/89740246-e5b52100-da3b-11ea-8434-0046b87b8b4c.png">

