### PR TITLE
Fix prop type error in ChatListItem

### DIFF
--- a/src/components/chat/ChatListItem.vue
+++ b/src/components/chat/ChatListItem.vue
@@ -92,10 +92,10 @@ export default {
       default: () => 0
     },
     valueUnread: {
-      type: Number,
+      type: String,
       // Not passed when all read
       required: false,
-      default: () => 0
+      default: () => ''
     },
     loaded: {
       type: Boolean,


### PR DESCRIPTION
Mistakenly, we set the valueUnread prop to be of type number. However,
it is passed in as a formatted balance already. This is causing
validation errors in the console. This commit adjusts the expected
prop type.
