### PR TITLE
Make UTXO storage API synchronous, move disk updates to background

### DIFF
--- a/src/adapters/level-outpoint-store.ts
+++ b/src/adapters/level-outpoint-store.ts
@@ -8,6 +8,7 @@ const appData = app.getPath('appData')
 export const store = new LevelOutpointStore(appData)
 
 store.Open()
+
 process.on('exit', (/* code */) => {
   store.Close()
 })

--- a/src/boot/setup-apis.js
+++ b/src/boot/setup-apis.js
@@ -108,6 +108,9 @@ function getWalletClient ({ store }) {
     unfreezeOutpoint (id) {
       return levelDbOutpointStore.unfreezeOutpoint(id)
     },
+    getOutpoints () {
+      return levelDbOutpointStore.getOutpoints()
+    },
     getOutpointIterator () {
       return levelDbOutpointStore.getOutpointIterator()
     },

--- a/src/store/modules/wallet.js
+++ b/src/store/modules/wallet.js
@@ -16,12 +16,13 @@ export async function rehydrateWallet (wallet) {
   wallet.utxos = {}
   // FIXME: This shouldn't be necessary, but the GUI needs real time
   // balance updates. In the future, we should just aggregate a total over time here.
-  const outpointIterator = await store.getOutpointIterator()
-  for await (const outpoint of outpointIterator) {
+  await store.loadData()
+  const outpoints = store.getOutpoints()
+  for (const [id, outpoint] of outpoints) {
     if (!outpoint.address) {
       continue
     }
-    wallet.utxos[calcId(outpoint)] = outpoint
+    wallet.utxos[id] = outpoint
   }
 }
 

--- a/src/wallet/storage/storage.ts
+++ b/src/wallet/storage/storage.ts
@@ -33,12 +33,14 @@ export class OutpointReturnResult implements IteratorReturnResult<Outpoint | und
 }
 
 export interface OutpointStore {
-  getOutpoint(id: OutpointId): Promise<Outpoint | undefined>;
-  deleteOutpoint(id: OutpointId): Promise<void>;
-  putOutpoint(outpoint: Outpoint): Promise<void>;
-  freezeOutpoint (outpointId: OutpointId): Promise<void>
-  unfreezeOutpoint (outpointId: OutpointId): Promise<void>
+  getOutpoint(id: OutpointId): Outpoint | undefined;
+  deleteOutpoint(id: OutpointId): void;
+  putOutpoint(outpoint: Outpoint): void;
+  freezeOutpoint (outpointId: OutpointId): void;
+  unfreezeOutpoint (outpointId: OutpointId): void;
 
-  getOutpointIterator(): Promise<AsyncIterator<Outpoint>>;
-  getFrozenOutpointIterator(): Promise<AsyncIterator<Outpoint>>;
+  getOutpoints(): Map<string, Outpoint>;
+
+  getOutpointIterator(): Promise<AsyncIterableIterator<Outpoint>>;
+  getFrozenOutpointIterator(): Promise<AsyncIterableIterator<Outpoint>>;
 }


### PR DESCRIPTION
Currently, using async functions to interact with UTXO selection means
that the event loop runs in between every UTXO load. This commit
obviates that by keeping an in memory cache of all UTXOs, and updating
the on-disk storage asynchronously.
