### PR TITLE
Ensure profile is setup with keyservers and relay servers on startup

### DIFF
--- a/src/components/dialogs/ProfileDialog.vue
+++ b/src/components/dialogs/ProfileDialog.vue
@@ -28,7 +28,6 @@
 <script>
 import { mapMutations, mapGetters } from 'vuex'
 import Profile from '../Profile'
-import { constructProfileMetadata, constructPriceFilter } from '../../relay/constructors'
 import { errorNotify } from '../../utils/notifications'
 
 export default {
@@ -57,20 +56,16 @@ export default {
 
       // Create metadata
       const idPrivKey = this.$wallet.identityPrivKey
-
       const acceptancePrice = this.relayData.inbox.acceptancePrice
-      const priceFilter = constructPriceFilter(true, acceptancePrice, acceptancePrice, idPrivKey)
-      const metadata = constructProfileMetadata(this.relayData.profile, priceFilter, idPrivKey)
 
       this.$q.loading.show({
         delay: 100,
         message: this.$t('profileDialog.pushingProfile')
       })
 
-      // Apply remotely
-      const idAddress = this.$wallet.myAddress
       try {
-        await client.putProfile(idAddress.toLegacyAddress(), metadata)
+        await client.updateProfile(idPrivKey, this.relayData.profile, acceptancePrice)
+        this.setRelayData(this.relayData)
       } catch (err) {
         console.error(err)
         // TODO: Move specialization down error displayer
@@ -82,10 +77,6 @@ export default {
         errorNotify(new Error(this.$t('profileDialog.unableContactRelay')))
         throw err
       }
-
-      // Apply
-      this.setRelayData(this.relayData)
-
       this.$q.loading.hide()
     }
   },

--- a/src/relay/client.js
+++ b/src/relay/client.js
@@ -7,7 +7,7 @@ import pop from '../pop'
 import { pingTimeout, relayReconnectInterval } from '../utils/constants'
 import VCard from 'vcf'
 import EventEmitter from 'events'
-import { constructStealthEntry, constructReplyEntry, constructTextEntry, constructImageEntry, constructMessage } from './constructors'
+import { constructStealthEntry, constructReplyEntry, constructTextEntry, constructImageEntry, constructMessage, constructProfileMetadata, constructPriceFilter } from './constructors'
 import { entryToImage, arrayBufferToBase64 } from '../utils/image'
 import { constructStampHDPrivateKey, constructHDStealthPrivateKey } from './crypto'
 import { messageMixin } from './extension'
@@ -705,6 +705,12 @@ export class RelayClient {
         }, 0)
       })
     }
+  }
+
+  async updateProfile (idPrivKey, profile, acceptancePrice) {
+    const priceFilter = constructPriceFilter(true, acceptancePrice, acceptancePrice, idPrivKey)
+    const metadata = constructProfileMetadata(profile, priceFilter, idPrivKey)
+    await this.putProfile(idPrivKey.toAddress('testnet').toLegacyAddress().toString(), metadata)
   }
 }
 


### PR DESCRIPTION
Currently, we only ever upload our profile, or keyserver metadata when
going through the setup. This means that if for some reason we change
backends our client will not automatically update keyserver/relay server
data.