### PR TITLE
Fix property type on SendBitcoinDialog component

### DIFF
--- a/src/components/dialogs/SendBitcoinDialog.vue
+++ b/src/components/dialogs/SendBitcoinDialog.vue
@@ -62,7 +62,7 @@ export default {
       default: () => ''
     },
     contact: {
-      type: String,
+      type: Object,
       default: () => ''
     }
   },


### PR DESCRIPTION
Mistaken property type was generating errors on the javascript console.
This fixes the type restriction.
