### PR TITLE
Fix event listeners in electrum client

### DIFF
--- a/src/wallet/index.js
+++ b/src/wallet/index.js
@@ -218,7 +218,7 @@ export class Wallet {
   async startListeners () {
     const ecl = await this.electrumClientPromise
     const addresses = Object.keys(this.allAddresses)
-    await ecl.events.on(
+    await ecl.on(
       'blockchain.scripthash.subscribe',
       async (result) => {
         const scriptHash = result[0]


### PR DESCRIPTION
Some update to the electrum client removed the `events` field and
instead directly inherited from the event emitter class. This means
we need to call `.on` directly rather than against the `events` field.
This commit fixes the bug this introduced.
