### PR TITLE
Use latest electrum-cash client which supports websockets

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "core-js": "^3.6.5",
     "dompurify": "^2.0.11",
     "electron-windows-badge": "^1.0.5",
-    "electrum-cash": "^1.0.1",
+    "electrum-cash": "^2.0.5",
     "emoji-mart-vue-fast": "^7.0.2",
     "google-protobuf": "^3.12.0-rc.1",
     "level": "^6.0.1",

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,29 +1,29 @@
+
+import { ElectrumTransport } from 'electrum-cash'
+
 // Electrum constants
 export const electrumServers = [
+  // Our mainnet server, we need to setup a testnet server as well.
   {
-    electrumURL: 'bch0.kister.net',
-    electrumPort: 51_002
-  },
-  {
-    electrumURL: 'blackie.c3-soft.com',
-    electrumPort: 60_002
-  },
-  {
-    electrumURL: 'electroncash.de',
-    electrumPort: 50_004
-  },
-  {
-    electrumURL: 'tbch.loping.net',
-    electrumPort: 60_002
-  },
-  // {
-  //   electrumURL: 'testnet.bitcoincash.network',
-  //   electrumPort: 60_002
-  // },
-  {
-    electrumURL: 'testnet.imaginary.cash',
-    electrumPort: 50_002
+    url: 'fulcrum.cashweb.io',
+    port: 443,
+    scheme: ElectrumTransport.WSS.Scheme
   }
+  // {
+  //   url: 'electrum.bitcoinabc.org',
+  //   port: 50004,
+  //   scheme: 'wss'
+  // },
+  // {
+  //   url: 'bchabc.fmarcosh.xyz',
+  //   port: 50003,
+  //   scheme: ElectrumTransport.WS.Scheme
+  // },
+  //   {
+  //     url: 'telectrum.bitcoinabc.org',
+  //     port: 60004,
+  //     scheme: ElectrumTransport.WSS.Scheme
+  //   }
 ]
 export const electrumPingInterval = 10_000
 

--- a/src/wallet/index.js
+++ b/src/wallet/index.js
@@ -218,7 +218,7 @@ export class Wallet {
   async startListeners () {
     const ecl = await this.electrumClientPromise
     const addresses = Object.keys(this.allAddresses)
-    await ecl.on(
+    await ecl.events.on(
       'blockchain.scripthash.subscribe',
       async (result) => {
         const scriptHash = result[0]

--- a/yarn.lock
+++ b/yarn.lock
@@ -4703,13 +4703,16 @@ electron@^11.0.3:
     "@types/node" "^12.0.12"
     extract-zip "^1.0.3"
 
-electrum-cash@^1.0.1:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/electrum-cash/-/electrum-cash-1.2.0.tgz#dc4049e25369ee87cc5eea50b9e23f73b426195e"
-  integrity sha512-NZarCF2U+6uXYd697GYAuP3qdDaFUx+6zWcO8SzyeNyRCNZaUm/rscUAm7+QCgNpUnj8tEGdLj5LG2mchaZRSQ==
+electrum-cash@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/electrum-cash/-/electrum-cash-2.0.5.tgz#e402bd767d0593611106e030bfd4ec92d5c8fe9c"
+  integrity sha512-3EoeJMgo2rHXvQqjdzwAemXWdFCO6ssmuaY2b9/AdVh4j7GFiJkgzLFptnjtjgWDZyaiP/miEuFYIbIq7ladGQ==
   dependencies:
+    "@types/ws" "^7.2.6"
     async-mutex "^0.2.4"
     debug "^4.1.1"
+    isomorphic-ws "^4.0.1"
+    ws "^7.3.1"
 
 elementtree@0.1.7:
   version "0.1.7"


### PR DESCRIPTION
Use the latest fulcrum cash version that supports websockets. This will
allow us to run Stamp in a web browser or with capacitor on mobile
devices. This new version also fixes several bugs.
