### PR TITLE
Use isomorphic websocket module for connecting to relay server

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "electrum-cash": "^1.0.1",
     "emoji-mart-vue-fast": "^7.0.2",
     "google-protobuf": "^3.12.0-rc.1",
+    "isomorphic-ws": "^4.0.1",
     "level": "^6.0.1",
     "marked": "^1.0.0",
     "moment": "^2.25.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1690,6 +1690,13 @@
     "@types/webpack-sources" "*"
     source-map "^0.6.0"
 
+"@types/ws@^7.2.6":
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-7.4.0.tgz#499690ea08736e05a8186113dac37769ab251a0e"
+  integrity sha512-Y29uQ3Uy+58bZrFLhX36hcI3Np37nqWE7ky5tjiDoy1GDZnIwVxS0CgF+s+1bXMzjKBFy+fqaRfb708iNzdinw==
+  dependencies:
+    "@types/node" "*"
+
 "@types/yargs-parser@*":
   version "15.0.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-15.0.0.tgz#cb3f9f741869e20cce330ffbeb9271590483882d"
@@ -6846,6 +6853,11 @@ isobject@^3.0.0, isobject@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
+
+isomorphic-ws@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz#55fd4cd6c5e6491e76dc125938dd863f5cd4f2dc"
+  integrity sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==
 
 isstream@~0.1.2:
   version "0.1.2"


### PR DESCRIPTION
This will allow connecting from both Electron and from Capacitor, and
web browsers in general. This will greatly improve our ability to
support other platforms. However, we also need to update the relay
server to support the full bearer token specification. The web browser
API for websockets does not allow setting headers, which means the
bearer token cannot be included in the Authorization header when
negotiating a websocket.