### PR TITLE
Re-enable CORS checks in Electron

### DIFF
--- a/src-electron/main-process/electron-main.js
+++ b/src-electron/main-process/electron-main.js
@@ -64,7 +64,6 @@ function createWindow () {
     useContentSize: true,
     webPreferences: {
       enableRemoteModule: true,
-      webSecurity: false, // Disable CORS checks
       nodeIntegration: process.env.QUASAR_NODE_INTEGRATION,
       nodeIntegrationInWorker: process.env.QUASAR_NODE_INTEGRATION
     }


### PR DESCRIPTION
Disabling this was unnecessary, and a red herring from when the relay
server was responding with 502s. These errors cause the JavaScript
http connection library to sometimes complain about CORS problems.
