### PR TITLE
Ensure generated seed phrases are always saved, and setup can be resumed

### DIFF
--- a/src/boot/setup-apis.js
+++ b/src/boot/setup-apis.js
@@ -135,7 +135,11 @@ export default async ({ store, Vue }) => {
   createAndBindNewElectrumClient({ Vue, observables: electrumObservables, wallet })
   const xPrivKey = store.getters['wallet/getXPrivKey']
   console.log('xpriv', xPrivKey)
-  if (xPrivKey) {
+
+  // Check if setup was finished.
+  // TODO: There should be a better way to do this.
+  const profile = store.getters['myProfile/getProfile']
+  if (xPrivKey && profile.name) {
     console.log('Loaded previous private key')
     wallet.setXPrivKey(xPrivKey)
   }

--- a/src/components/setup/SeedStep.vue
+++ b/src/components/setup/SeedStep.vue
@@ -171,7 +171,7 @@ export default {
   },
   data () {
     return {
-      generatedSeed: generateMnemonic(),
+      generatedSeed: this.seedData.generatedSeed,
       importedSeed: this.seedData.importedSeed,
       tab: this.seedData.type
     }

--- a/src/pages/Setup.vue
+++ b/src/pages/Setup.vue
@@ -103,6 +103,7 @@ import { errorNotify } from '../utils/notifications'
 import WalletGenWorker from 'worker-loader!../workers/xpriv_generate.js'
 
 import { HDPrivateKey } from 'bitcore-lib-cash'
+import { generateMnemonic } from 'bip39'
 
 Vue.use(VueRouter)
 
@@ -125,8 +126,8 @@ export default {
       bio: '',
       seedData: {
         type: 'new',
-        generatedSeed: '',
-        importedSeed: '',
+        generatedSeed: this.getSeedPhrase() || generateMnemonic(),
+        importedSeed: this.getSeedPhrase() || '',
         valid: false
       },
       seed: null,
@@ -155,7 +156,8 @@ export default {
     }),
     ...mapGetters({
       getUpdateInterval: 'contacts/getUpdateInterval',
-      getDarkMode: 'appearance/getDarkMode'
+      getDarkMode: 'appearance/getDarkMode',
+      getSeedPhrase: 'wallet/getSeedPhrase'
     }),
     ...mapMutations({
       setRelayData: 'myProfile/setRelayData',
@@ -239,6 +241,7 @@ export default {
       } else {
         this.seed = this.seedData.importedSeed
       }
+      this.setSeedPhrase(this.seed)
       worker.postMessage(this.seed)
     },
     async nextDeposit () {


### PR DESCRIPTION
Due to state errors around how seeds are generated and stored during
setup, the setup could not be resumed if the xpriv had been generated,
but the setup not completed. This commit addresses those issues in order
to ensure that funds are not lost during a partial setup.

However, from the areas touched, it should be apparent that the way in
which this state is being handled is rather tangled. There needs to be
an overarching concept for "setup complete" rather than it being
inferred from various other variables being set.

Fixes #338