### PR TITLE
Ensure UTXOs are cleared from leveldb during Setup

### DIFF
--- a/src/pages/Setup.vue
+++ b/src/pages/Setup.vue
@@ -174,6 +174,7 @@ export default {
       // TODO: This should not be done "behind the back" of the wallet object
       // (e.g. we should not be fiddling with the store directly here)
       this.resetWallet()
+      this.$wallet.clearUtxos()
 
       this.$q.loading.show({
         delay: 100,

--- a/src/wallet/index.js
+++ b/src/wallet/index.js
@@ -634,4 +634,15 @@ export class Wallet {
     // TODO: Nobody should be calling this outside of the wallet
     await this.storage.deleteOutpoint(id)
   }
+
+  // Warning, this should only be used during initial setup to ensure the
+  // levelDB database has been cleared.
+  // This needs to happen when the seed has potentially changed after
+  // the UTXOs have been refreshed.
+  async clearUtxos () {
+    const outpoints = await this.storage.getOutpoints()
+    for (const [outpointId] of outpoints) {
+      this.deleteOutpoint(outpointId)
+    }
+  }
 }


### PR DESCRIPTION
Not reseting leveldb caused  the balance to not properly refresh due to
the desync between the rehydrated wallet being reset, but not the
leveldb store when the setup regenerates a new wallet.

Thus, we need to clear out the actual wallet at the same time. In the
cuture we should remove explicit UTXO tracking in the Vuex store, and
instead only update the balances as UTXOs are deleted/removed.
