### PR TITLE
Ensure capacitor adds toolbar space

### DIFF
--- a/quasar.conf.js
+++ b/quasar.conf.js
@@ -177,7 +177,8 @@ module.exports = configure(function (ctx) {
 
     // Full list of options: https://quasar.dev/quasar-cli/developing-capacitor-apps/configuring-capacitor
     capacitor: {
-      hideSplashscreen: true
+      hideSplashscreen: true,
+      iosStatusBarPadding: true
     },
 
     // Full list of options: https://quasar.dev/quasar-cli/developing-electron-apps/configuring-electron


### PR DESCRIPTION
Currently, on iOS the toolbars clobber part of the screen. This should
address that problem.
