### PR TITLE
Fix Websockets to use Arraybuffers instead of Blobs

### DIFF
--- a/src/relay/client.js
+++ b/src/relay/client.js
@@ -100,6 +100,7 @@ export class RelayClient {
     url.protocol = 'wss'
     url.searchParams.set('access_token', this.token)
     const socket = new WebSocket(url.toString())
+    socket.binaryType = 'arraybuffer'
 
     socket.onmessage = event => {
       const buffer = event.data


### PR DESCRIPTION
The rest of the code expects arraybuffers. But the default is Blobs
for the browser websocket API. This tells it to use array buffers
instead.