### PR TITLE
Fix buffer types being passed into bitcore lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@vue/composition-api": "^0.6.4",
     "axios": "^0.18.1",
     "bip39": "^3.0.2",
-    "bitcore-lib-cash": "^8.20.1",
+    "bitcore-lib-cash": "^8.23.0",
     "bluebird": "^3.7.2",
     "bn.js": "file:./local_modules/bn.js",
     "core-js": "^3.6.5",

--- a/src/relay/constructors.js
+++ b/src/relay/constructors.js
@@ -9,7 +9,7 @@ import { crypto, PublicKey, PrivateKey } from 'bitcore-lib-cash'
 import assert from 'assert'
 
 export const constructStampTransactions = async function (wallet, payloadDigest, destPubKey, amount) {
-  assert(payloadDigest instanceof Buffer)
+  assert(payloadDigest instanceof Buffer, 'digestPayload is wrong type')
 
   // Stamp output
   const stampHDPubKey = constructStampHDPublicKey(payloadDigest, destPubKey)
@@ -113,7 +113,7 @@ export const constructMessage = async function (wallet, plainTextPayload, source
 }
 
 export const constructReplyEntry = function ({ payloadDigest }) {
-  assert(typeof payloadDigest === 'string')
+  assert(typeof payloadDigest === 'string', 'digestPayload is wrong type')
   const payloadDigestBuffer = Buffer.from(payloadDigest, 'hex')
 
   const entry = new PayloadEntry()

--- a/src/relay/crypto.js
+++ b/src/relay/crypto.js
@@ -3,7 +3,7 @@ import { PrivateKey, PublicKey, crypto, HDPublicKey, HDPrivateKey } from 'bitcor
 import forge from 'node-forge'
 
 export const constructPayloadHmac = function (sharedKey, payloadDigest) {
-  return crypto.Hash.sha256hmac(sharedKey, payloadDigest)
+  return crypto.Hash.sha256hmac(sharedKey, Buffer.from(payloadDigest))
 }
 
 export const constructMergedKey = function (privateKey, publicKey) {
@@ -13,7 +13,8 @@ export const constructMergedKey = function (privateKey, publicKey) {
 export const constructSharedKey = function (privateKey, publicKey, salt) {
   const mergedKey = constructMergedKey(privateKey, publicKey)
   const rawMergedKey = mergedKey.toBuffer()
-  return crypto.Hash.sha256hmac(salt, rawMergedKey)
+  const sharedKey = crypto.Hash.sha256hmac(Buffer.from(salt), rawMergedKey)
+  return sharedKey
 }
 
 export const constructStealthPublicKey = function (emphemeralPrivKey, destinationPublicKey) {

--- a/src/store/modules/chats.js
+++ b/src/store/modules/chats.js
@@ -35,21 +35,22 @@ export async function rehydateChat (chatState) {
       contact.totalValue = 0
     }
   }
+  const localStore = await store
 
-  const messageIterator = await store.getIterator()
+  const messageIterator = await localStore.getIterator()
   // Todo, this rehydrate stuff is common to receiveMessage
   for await (const messageWrapper of messageIterator) {
     if (!messageWrapper.newMsg) {
       continue
     }
     const { index, newMsg, copartyAddress } = messageWrapper
-    assert(newMsg.outbound !== undefined)
-    assert(newMsg.status !== undefined)
-    assert(newMsg.receivedTime !== undefined)
-    assert(newMsg.serverTime !== undefined)
-    assert(newMsg.items !== undefined)
-    assert(newMsg.outpoints !== undefined)
-    assert(newMsg.senderAddress !== undefined)
+    assert(newMsg.outbound !== undefined, 'outbound is not defined')
+    assert(newMsg.status !== undefined, 'status is not defined')
+    assert(newMsg.receivedTime !== undefined, 'receivedTime is not defined')
+    assert(newMsg.serverTime !== undefined, 'serverTime is not defined')
+    assert(newMsg.items !== undefined, 'items is not defined')
+    assert(newMsg.outpoints !== undefined, 'outpoints is not defined')
+    assert(newMsg.senderAddress !== undefined, 'senderAddress is not defined')
 
     const message = { payloadDigest: index, ...newMsg }
     if (!chatState.messages) {
@@ -214,13 +215,13 @@ export default {
         retryData,
         senderAddress
       }
-      assert(newMsg.outbound !== undefined)
-      assert(newMsg.status !== undefined)
-      assert(newMsg.receivedTime !== undefined)
-      assert(newMsg.serverTime !== undefined)
-      assert(newMsg.items !== undefined)
-      assert(newMsg.outpoints !== undefined)
-      assert(newMsg.senderAddress !== undefined, 'missing sender address')
+      assert(newMsg.outbound !== undefined, 'outbound is not defined')
+      assert(newMsg.status !== undefined, 'status is not defined')
+      assert(newMsg.receivedTime !== undefined, 'receivedTime is not defined')
+      assert(newMsg.serverTime !== undefined, 'serverTime is not defined')
+      assert(newMsg.items !== undefined, 'items is not defined')
+      assert(newMsg.outpoints !== undefined, 'outpoints is not defined')
+      assert(newMsg.senderAddress !== undefined, 'senderAddress is not defined')
 
       const message = { payloadDigest: index, ...newMsg }
       if (index in state.messages) {
@@ -249,15 +250,15 @@ export default {
       Vue.delete(state.chats, address)
     },
     receiveMessage (state, { address, index, newMsg }) {
-      assert(newMsg.outbound !== undefined)
-      assert(newMsg.status !== undefined)
-      assert(newMsg.receivedTime !== undefined)
-      assert(newMsg.serverTime !== undefined)
-      assert(newMsg.items !== undefined)
-      assert(newMsg.outpoints !== undefined)
-      assert(newMsg.senderAddress !== undefined)
-      assert(address !== undefined)
-      assert(index !== undefined)
+      assert(newMsg.outbound !== undefined, 'outbound is not defined')
+      assert(newMsg.status !== undefined, 'status is not defined')
+      assert(newMsg.receivedTime !== undefined, 'receivedTime is not defined')
+      assert(newMsg.serverTime !== undefined, 'serverTime is not defined')
+      assert(newMsg.items !== undefined, 'items is not defined')
+      assert(newMsg.outpoints !== undefined, 'outpoints is not defined')
+      assert(newMsg.senderAddress !== undefined, 'senderAddress is not defined')
+      assert(address !== undefined, 'address is not defined')
+      assert(index !== undefined, 'index is not defined')
 
       const message = { payloadDigest: index, ...newMsg }
       if (index in state.messages) {
@@ -317,7 +318,7 @@ export default {
       setInterval(() => { dispatch('refresh') }, 1_000)
     },
     setStampAmount ({ commit }, { address, stampAmount }) {
-      assert(typeof stampAmount === 'number')
+      assert(typeof stampAmount === 'number', 'stampAmount wrong type')
       commit('setStampAmount', { address, stampAmount })
     },
     receiveMessage ({ dispatch, commit, rootGetters, getters }, { outbound, copartyAddress, copartyPubKey, index, newMsg }) {

--- a/src/wallet/index.js
+++ b/src/wallet/index.js
@@ -467,7 +467,7 @@ export class Wallet {
     const calcAmounts = (splits, amount) => {
       const splitPoints = []
       let amountLeft = amount
-      assert(splits > 0)
+      assert(splits > 0, 'transaction set split number invalid')
       while (splitPoints.length < splits - 1) {
         const splitPoint = Math.floor(Math.random() * (amountLeft - 2 * minimumOutputAmount)) + minimumOutputAmount
         if (splitPoint < minimumOutputAmount) {
@@ -613,12 +613,12 @@ export class Wallet {
   }
 
   putOutpoint (utxo) {
-    assert(utxo.type !== undefined)
-    assert(utxo.privKey !== undefined)
-    assert(utxo.address !== undefined)
-    assert(utxo.satoshis !== undefined)
-    assert(utxo.txId !== undefined)
-    assert(utxo.outputIndex !== undefined)
+    assert(utxo.type !== undefined, 'putOupoint utxo wrong format')
+    assert(utxo.privKey !== undefined, 'putOupoint utxo wrong format')
+    assert(utxo.address !== undefined, 'putOupoint utxo wrong format')
+    assert(utxo.satoshis !== undefined, 'putOupoint utxo wrong format')
+    assert(utxo.txId !== undefined, 'putOupoint utxo wrong format')
+    assert(utxo.outputIndex !== undefined, 'putOupoint utxo wrong format')
     console.log('adding utxo', calcId(utxo))
     // TODO: Nobody should be calling this outside of the wallet
     return this.storage.putOutpoint(utxo)

--- a/yarn.lock
+++ b/yarn.lock
@@ -2740,7 +2740,7 @@ bip39@^3.0.2:
     pbkdf2 "^3.0.9"
     randombytes "^2.0.1"
 
-bitcore-lib-cash@^8.20.1:
+bitcore-lib-cash@^8.23.0:
   version "8.23.1"
   resolved "https://registry.yarnpkg.com/bitcore-lib-cash/-/bitcore-lib-cash-8.23.1.tgz#188be56f15f4b4d49aa85777cb998252be67cf60"
   integrity sha512-QenfM9v5L4UdicRbmMYQbxeNqJjzifBT7DQbK0ambqkxiaUi7k5qY62Gx0N2GIdY5B+edmMib+xCbadaHRTN+w==


### PR DESCRIPTION
These only happened to work in node. They do not work in the browser.
This commit properly converts them to buffers before passing them
through to bitcore.
