### PR TITLE
Add capacitor as a dependency so we can special case for mobile

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "build-android": "quasar build  -m capacitor -T android"
   },
   "dependencies": {
+    "@capacitor/core": "^2.4.3",
     "@quasar/extras": "^1.9.10",
     "@vue/composition-api": "^0.6.4",
     "axios": "^0.18.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -911,6 +911,13 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@capacitor/core@^2.4.3":
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/@capacitor/core/-/core-2.4.3.tgz#256cdc931953c9f3c687f86c5310787cfd69f13f"
+  integrity sha512-AaLhXryFK65OvfS9zuw3qw6gVbNjeHoIAzvhrzcI0OWJo6Qi8gOIz4rraD35UKSETkRm+H7auhSTAj6Avy5lHQ==
+  dependencies:
+    tslib "^1.9.0"
+
 "@cnakazawa/watch@^1.0.3":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@cnakazawa/watch/-/watch-1.0.4.tgz#f864ae85004d0fcab6f50be9141c4da368d1656a"
@@ -2806,6 +2813,9 @@ bn.js@^5.0.0, bn.js@^5.1.1:
   version "5.1.3"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.1.3.tgz#beca005408f642ebebea80b042b4d18d2ac0ee6b"
   integrity sha512-GkTiFpjFtUzU9CbMeJ5iazkCzGL3jrhzerzZIuqLABjbwRaFt33I9tUdSNryIptM+RxDet6OKm2WnLXzW51KsQ==
+
+"bn.js@file:./local_modules/bn.js":
+  version "4.11.9"
 
 body-parser@1.19.0:
   version "1.19.0"
@@ -6304,7 +6314,7 @@ icss-utils@^4.0.0, icss-utils@^4.1.1:
   dependencies:
     postcss "^7.0.14"
 
-ieee754@^1.1.13, ieee754@^1.1.4:
+ieee754@^1.1.13, ieee754@^1.1.4, ieee754@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==


### PR DESCRIPTION
Capacitor comes with a number of plugins we will need to run in the
browser/mobile. Similar to some of the electron-specific APIs. We will
polyfill the specific items we use in the future.
