### PR TITLE
Make message store async so it can be used with IndexDB in browser

### DIFF
--- a/src/adapters/vuex-relay-adapter.js
+++ b/src/adapters/vuex-relay-adapter.js
@@ -2,14 +2,14 @@ import { RelayClient } from '../relay/client'
 import { defaultRelayUrl } from '../utils/constants'
 import { store as levelDbStore } from '../adapters/level-message-store'
 
-export function getRelayClient ({ wallet, electrumClient, store, relayUrl = defaultRelayUrl }) {
+export async function getRelayClient ({ wallet, electrumClient, store, relayUrl = defaultRelayUrl }) {
   const observables = { connected: false }
   const client = new RelayClient(relayUrl, wallet, electrumClient, {
     getPubKey: (address) => {
       const destPubKey = store.getters['contacts/getPubKey'](address)
       return destPubKey
     },
-    messageStore: levelDbStore
+    messageStore: await levelDbStore
   })
   client.events.on('disconnected', () => {
     observables.connected = false

--- a/src/pages/Setup.vue
+++ b/src/pages/Setup.vue
@@ -289,7 +289,7 @@ export default {
       // Get profile from relay server
       // We do this first to prevent uploading broken URL to keyserver
       const idAddress = this.$wallet.myAddress
-      const { client: relayClient } = getRelayClient({ relayUrl: this.relayUrl, store: this.$store, wallet: this.$wallet })
+      const { client: relayClient } = await getRelayClient({ relayUrl: this.relayUrl, store: this.$store, wallet: this.$wallet })
 
       this.$q.loading.show({
         delay: 100,
@@ -335,7 +335,7 @@ export default {
       }
     },
     async setupRelay () {
-      const { client: relayClient } = getRelayClient({ relayUrl: this.relayUrl, store: this.$store, electrumClientPromise: this.$electrumClientPromise, wallet: this.$wallet })
+      const { client: relayClient } = await getRelayClient({ relayUrl: this.relayUrl, store: this.$store, electrumClientPromise: this.$electrumClientPromise, wallet: this.$wallet })
 
       // Set filter
       this.$q.loading.show({

--- a/src/store/modules/contacts.js
+++ b/src/store/modules/contacts.js
@@ -133,7 +133,7 @@ export default {
         const handler = new KeyserverHandler()
         const relayURL = await handler.getRelayUrl(address)
 
-        const { client: relayClient } = getRelayClient({ relayURL })
+        const { client: relayClient } = await getRelayClient({ relayURL })
         const relayData = await relayClient.getRelayData(address)
         commit('updateContact', { address, profile: relayData.profile, inbox: relayData.inbox })
       } catch (err) {

--- a/src/store/modules/wallet.js
+++ b/src/store/modules/wallet.js
@@ -1,7 +1,7 @@
 import Vue from 'vue'
 
 import { calcId } from '../../wallet/helpers'
-import { store } from '../../adapters/level-outpoint-store'
+import { store as levelOutpointStore } from '../../adapters/level-outpoint-store'
 
 import { HDPrivateKey } from 'bitcore-lib-cash'
 
@@ -16,6 +16,7 @@ export async function rehydrateWallet (wallet) {
   wallet.utxos = {}
   // FIXME: This shouldn't be necessary, but the GUI needs real time
   // balance updates. In the future, we should just aggregate a total over time here.
+  const store = await levelOutpointStore
   await store.loadData()
   const outpoints = store.getOutpoints()
   for (const [id, outpoint] of outpoints) {


### PR DESCRIPTION
Level module is synchronouse in electron/node, however in the browser
it uses IndexDB. This requires that everything downstream be async.
However, we need to switch away from IndexDB entirely, as there is
eviction policies on mobile that we may run into.
