### PR TITLE
Move chat list to drawer for better mobile support

### DIFF
--- a/src/components/chat/ChatList.vue
+++ b/src/components/chat/ChatList.vue
@@ -1,38 +1,5 @@
 <template>
-  <div class="column full-height">
-    <!-- Wallet dialog -->
-    <q-dialog v-model="walletOpen">
-      <receive-bitcoin-dialog />
-    </q-dialog>
-
-    <!-- Relay reconnect dialog -->
-    <q-dialog v-model="relayConnectOpen">
-      <relay-connect-dialog />
-    </q-dialog>
-
-    <!-- New contact dialog -->
-    <q-dialog v-model="newContactOpen">
-      <new-contact-dialog />
-    </q-dialog>
-
-    <q-toolbar>
-      <q-btn
-        class="q-px-sm"
-        flat
-        dense
-        @click="toggleMyDrawerOpen"
-        icon="menu"
-      />
-      <q-space />
-      <q-btn
-        v-if="!compact"
-        class="q-px-sm"
-        flat
-        dense
-        @click="newContactOpen = true"
-        icon="add"
-      />
-    </q-toolbar>
+  <div class='full-width column col'>
     <q-scroll-area class="q-px-none col">
       <q-list>
         <q-separator />
@@ -52,46 +19,6 @@
         </q-item>
       </q-list>
     </q-scroll-area>
-    <q-list>
-      <q-separator />
-      <q-item
-        v-show="!compact"
-        clickable
-      >
-        <q-item-section
-          @click="walletOpen=true"
-        >
-          <q-item-label>{{ $t('chatList.balance') }}</q-item-label>
-          <q-item-label caption>
-            {{ formattedBalance }}
-          </q-item-label>
-        </q-item-section>
-        <q-item-section
-          v-if="!walletConnected"
-          side
-        >
-          <q-btn
-            icon="account_balance_wallet"
-            flat
-            round
-            color="red"
-          />
-        </q-item-section>
-        <q-item-section
-          v-if="!relayConnected"
-          side
-          clickable
-          @click="relayConnectOpen=true"
-        >
-          <q-btn
-            icon="email"
-            flat
-            round
-            color="red"
-          />
-        </q-item-section>
-      </q-item>
-    </q-list>
   </div>
 </template>
 
@@ -99,9 +26,6 @@
 import ChatListItem from './ChatListItem.vue'
 import { mapGetters } from 'vuex'
 import { formatBalance } from '../../utils/formatting'
-import ReceiveBitcoinDialog from '../dialogs/ReceiveBitcoinDialog.vue'
-import NewContactDialog from '../dialogs/NewContactDialog.vue'
-import RelayConnectDialog from '../dialogs/RelayConnectDialog.vue'
 
 export default {
   props: {
@@ -115,28 +39,22 @@ export default {
     }
   },
   components: {
-    ChatListItem,
-    ReceiveBitcoinDialog,
-    RelayConnectDialog,
-    NewContactDialog
+    ChatListItem
   },
   data () {
     return {
-      walletOpen: false,
-      relayConnectOpen: false,
-      newContactOpen: false
     }
   },
   methods: {
+    toggleMyDrawerOpen () {
+      this.$emit('toggleMyDrawerOpen')
+    },
     formatBalance (balance) {
       if (!balance) {
         return
       }
       return formatBalance(balance)
     },
-    toggleMyDrawerOpen () {
-      this.$emit('toggleMyDrawerOpen')
-    }
   },
   computed: {
     ...mapGetters({
@@ -144,15 +62,6 @@ export default {
       getNumUnread: 'chats/getNumUnread',
       balance: 'wallet/balance'
     }),
-    relayConnected () {
-      return this.$relay.connected
-    },
-    walletConnected () {
-      return this.$electrum.connected
-    },
-    formattedBalance () {
-      return formatBalance(this.balance)
-    }
   }
 }
 </script>

--- a/src/components/panels/LeftDrawer.vue
+++ b/src/components/panels/LeftDrawer.vue
@@ -1,0 +1,187 @@
+<template>
+  <div class="column full-height">
+    <!-- Wallet dialog -->
+    <q-dialog v-model="walletOpen">
+      <receive-bitcoin-dialog />
+    </q-dialog>
+
+    <!-- Relay reconnect dialog -->
+    <q-dialog v-model="relayConnectOpen">
+      <relay-connect-dialog />
+    </q-dialog>
+
+    <!-- New contact dialog -->
+    <q-dialog v-model="newContactOpen">
+      <new-contact-dialog />
+    </q-dialog>
+    <q-tabs v-model="tab">
+      <q-tab
+        name="settings"
+        icon="settings"
+      />
+      <q-tab
+        name="contacts"
+        icon="contacts"
+      />
+    </q-tabs>
+
+    <settings-panel v-show="tab=='settings'" />
+
+    <chat-list
+      v-show="tab=='contacts'"
+      :loaded="loaded"
+      @toggleMyDrawerOpen="toggleMyDrawerOpen"
+      :compact="false"
+    />
+
+    <q-list>
+      <q-separator />
+      <q-item clickable>
+        <q-item-section @click="walletOpen=true">
+          <q-item-label>{{ $t('chatList.balance') }}</q-item-label>
+          <q-item-label caption>
+            {{ formattedBalance }}
+          </q-item-label>
+        </q-item-section>
+        <q-item-section
+          v-if="!walletConnected"
+          side
+        >
+          <q-btn
+            icon="account_balance_wallet"
+            flat
+            round
+            color="red"
+          />
+        </q-item-section>
+        <q-item-section
+          v-if="!relayConnected"
+          side
+          clickable
+          @click="relayConnectOpen=true"
+        >
+          <q-btn
+            icon="email"
+            flat
+            round
+            color="red"
+          />
+        </q-item-section>
+      </q-item>
+    </q-list>
+  </div>
+</template>
+
+<script>
+import Chat from '../../pages/Chat.vue'
+import ChatList from '../chat/ChatList.vue'
+import SettingsPanel from '../panels/SettingsPanel.vue'
+import ContactPanel from '../panels/ContactPanel.vue'
+import ContactBookDialog from '../dialogs/ContactBookDialog.vue'
+import { mapActions, mapGetters, mapState } from 'vuex'
+import { debounce } from 'quasar'
+import { defaultContacts } from '../../utils/constants'
+import KeyserverHandler from '../../keyserver/handler'
+import { errorNotify } from '../../utils/notifications'
+import ReceiveBitcoinDialog from '../dialogs/ReceiveBitcoinDialog.vue'
+import NewContactDialog from '../dialogs/NewContactDialog.vue'
+import RelayConnectDialog from '../dialogs/RelayConnectDialog.vue'
+import { formatBalance } from '../../utils/formatting'
+
+const compactWidth = 70
+const compactCutoff = 325
+const compactMidpoint = (compactCutoff + compactWidth) / 2
+
+export default {
+  components: {
+    Chat,
+    ChatList,
+    ContactPanel,
+    SettingsPanel,
+    ContactBookDialog,
+    ReceiveBitcoinDialog,
+    RelayConnectDialog,
+    NewContactDialog
+  },
+  props: {
+    loaded: {
+      type: Boolean,
+      required: true
+    },
+  },
+  data () {
+    return {
+      tab: "contacts",
+      // My Drawer
+      walletOpen: false,
+      relayConnectOpen: false,
+      newContactOpen: false,
+      //
+      trueSplitterRatio: compactCutoff,
+    }
+  },
+  methods: {
+    ...mapActions({
+      setActiveChat: 'chats/setActiveChat',
+      addDefaultContact: 'contacts/addDefaultContact'
+    }),
+    ...mapGetters({
+      getDarkMode: 'appearance/getDarkMode'
+    }),
+    tweak (offset, viewportHeight) {
+      const height = viewportHeight - offset + 'px'
+      return { height, minHeight: height }
+    },
+    toggleContactDrawerOpen () {
+      this.contactDrawerOpen = !this.contactDrawerOpen
+    },
+    toggleContactBookOpen () {
+      this.contactBookOpen = !this.contactBookOpen
+    },
+    toggleMyDrawerOpen () {
+      if (this.compact) {
+        this.compact = false
+        this.trueSplitterRatio = compactCutoff
+      }
+      this.myDrawerOpen = !this.myDrawerOpen
+    },
+    shortcutKeyListener (e) {
+      if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+        this.toggleContactBookOpen()
+      }
+    },
+    contactClicked (address) {
+      this.contactBookOpen = false
+
+      return this.setActiveChat(address)
+    },
+    formatBalance (balance) {
+      if (!balance) {
+        return
+      }
+      return formatBalance(balance)
+    },
+  },
+  computed: {
+    ...mapState('chats', ['chats', 'activeChatAddr']),
+    ...mapGetters({
+      getContact: 'contacts/getContact',
+      lastReceived: 'chats/getLastReceived',
+      totalUnread: 'chats/totalUnread',
+      getRelayData: 'myProfile/getRelayData',
+      getSortedChatOrder: 'chats/getSortedChatOrder',
+      getNumUnread: 'chats/getNumUnread',
+      balance: 'wallet/balance'
+    }),
+    relayConnected () {
+      return this.$relay.connected
+    },
+    walletConnected () {
+      return this.$electrum.connected
+    },
+    formattedBalance () {
+      return formatBalance(this.balance)
+    }
+  }
+}
+</script>

--- a/src/components/panels/SettingsPanel.vue
+++ b/src/components/panels/SettingsPanel.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="column full-height">
+  <div class='full-width column col'>
     <contact-card
       :address="getMyAddressStr"
       :name="getProfile.name"
@@ -43,7 +43,7 @@
     <div class="flex-break" />
     <!-- Drawer -->
     <q-scroll-area class="col">
-      <q-list padding>
+      <q-list>
         <q-item
           clickable
           v-ripple

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -2,17 +2,15 @@
   <q-layout view="hHr LpR lff">
     <q-drawer
       v-model="myDrawerOpen"
-      overlay
-      behavior="mobile"
       :width="splitterRatio"
       :breakpoint="400"
     >
-      <settings-panel />
+      <left-drawer :loaded="loaded" />
     </q-drawer>
     <q-drawer
       v-model="contactDrawerOpen"
       side="right"
-      :width="300"
+      :width="splitterRatio"
       :breakpoint="400"
     >
       <contact-panel
@@ -26,36 +24,18 @@
     </q-dialog>
     <q-page-container>
       <q-page :style-fn="tweak">
-        <q-splitter
-          v-model="splitterRatio"
-          class="full-height"
-          unit="px"
-          emit-immediately
-          :limits="[compactWidth, 1000]"
-        >
-          <template v-slot:before>
-            <chat-list
-              class="full-height"
-              :loaded="loaded"
-              @toggleMyDrawerOpen="toggleMyDrawerOpen"
-              :compact="compact"
-            />
-          </template>
-
-          <template v-slot:after>
-            <chat
-              v-for="(item, index) in chats"
-              v-show="activeChatAddr === index"
-              :key="index"
-              :address="index"
-              :messages="item.messages"
-              :active="activeChatAddr === index"
-              :style="`height: inherit; min-height: inherit;`"
-              :loaded="loaded"
-              @toggleContactDrawerOpen="toggleContactDrawerOpen"
-            />
-          </template>
-        </q-splitter>
+        <chat
+          v-for="(item, index) in chats"
+          v-show="activeChatAddr === index"
+          :key="index"
+          :address="index"
+          :messages="item.messages"
+          :active="activeChatAddr === index"
+          :style="`height: inherit; min-height: inherit;`"
+          :loaded="loaded"
+          @toggleContactDrawerOpen="toggleContactDrawerOpen"
+          @toggleMyDrawerOpen="toggleMyDrawerOpen"
+        />
       </q-page>
     </q-page-container>
   </q-layout>
@@ -65,6 +45,7 @@
 import Chat from '../pages/Chat.vue'
 import ChatList from '../components/chat/ChatList.vue'
 import SettingsPanel from '../components/panels/SettingsPanel.vue'
+import LeftDrawer from '../components/panels/LeftDrawer.vue'
 import ContactPanel from '../components/panels/ContactPanel.vue'
 import ContactBookDialog from '../components/dialogs/ContactBookDialog.vue'
 import { mapActions, mapGetters, mapState } from 'vuex'
@@ -83,7 +64,8 @@ export default {
     ChatList,
     ContactPanel,
     SettingsPanel,
-    ContactBookDialog
+    LeftDrawer,
+    ContactBookDialog,
   },
   data () {
     return {

--- a/src/pages/Chat.vue
+++ b/src/pages/Chat.vue
@@ -21,6 +21,13 @@
 
     <q-header>
       <q-toolbar class="q-pl-sm">
+        <q-btn
+          class="q-px-sm"
+          flat
+          dense
+          @click="toggleSettingsDrawerOpen"
+          icon="menu"
+        />
         <q-avatar rounded>
           <img :src="contactProfile.avatar">
         </q-avatar>
@@ -267,6 +274,9 @@ export default {
         return true
       }
       return previousMessage.senderAddress !== message.senderAddress
+    },
+    toggleSettingsDrawerOpen () {
+      this.$emit('toggleMyDrawerOpen')
     },
     toggleContactDrawerOpen () {
       this.$emit('toggleContactDrawerOpen')


### PR DESCRIPTION
We had originally moved the chat list out of the drawer because it was
not resizable there, and looked bad on desktop. However, putting it
there works well for mobile for the time being, as we want to get to
an MVP position for mobile first.
