### PR TITLE
Fix tslint configuration issues preventing build

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,7 +17,12 @@ module.exports = {
     project: resolve(__dirname, './tsconfig.json'),
     tsconfigRootDir: __dirname,
     ecmaVersion: 2018, // Allows for the parsing of modern ECMAScript features
-    sourceType: 'module' // Allows for the use of imports
+    sourceType: 'module', // Allows for the use of imports
+
+    projectFolderIgnoreList: [
+      "/node_modules/",
+      "/local_modules/",
+    ]
   },
 
   env: {

--- a/src/boot/i18n.ts
+++ b/src/boot/i18n.ts
@@ -1,5 +1,5 @@
 import { boot } from 'quasar/wrappers'
-import messages from 'src/i18n'
+import messages from '../i18n'
 import Vue from 'vue'
 import VueI18n from 'vue-i18n'
 

--- a/src/components/panels/SettingsPanel.vue
+++ b/src/components/panels/SettingsPanel.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class='full-width column col'>
+  <div class="full-width column col">
     <contact-card
       :address="getMyAddressStr"
       :name="getProfile.name"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,5 +3,12 @@
   "compilerOptions": {
     "target": "es2017",
     "baseUrl": "."
-  }
+  },
+  "include": [
+    "src",
+    "local_modules/bn.js/lib/bn.js"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6314,7 +6314,7 @@ icss-utils@^4.0.0, icss-utils@^4.1.1:
   dependencies:
     postcss "^7.0.14"
 
-ieee754@^1.1.13, ieee754@^1.1.4, ieee754@^1.2.1:
+ieee754@^1.1.13, ieee754@^1.1.4:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
@@ -8349,11 +8349,6 @@ node-emoji@^1.10.0:
   integrity sha512-Yt3384If5H6BYGVHiHwTL+99OzJKHhgp82S8/dktEK73T26BazdgZ4JZh92xSVtGNJvz9UbXdNAc5hcrXV42vw==
   dependencies:
     lodash.toarray "^4.4.0"
-
-node-forge@^0.10.0:
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.10.0.tgz#32dea2afb3e9926f02ee5ce8794902691a676bf3"
-  integrity sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==
 
 node-forge@^0.10.0:
   version "0.10.0"


### PR DESCRIPTION
TSLint has been running out of memory due to trying to lint files
which are not appropriately part of the project. This commit updates
the configuration and fixes a few lint errors that were hanging
around as a result of being unable to build.
