### PR TITLE
Ensure drawer opens on first import

### DIFF
--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -4,6 +4,7 @@
       v-model="myDrawerOpen"
       :width="splitterRatio"
       :breakpoint="400"
+      show-if-above
     >
       <left-drawer :loaded="loaded" />
     </q-drawer>
@@ -67,7 +68,7 @@ export default {
     return {
       trueSplitterRatio: compactCutoff,
       loaded: false,
-      myDrawerOpen: false,
+      myDrawerOpen: !!this.activeChatAddr,
       contactDrawerOpen: false,
       contactBookOpen: false,
       compact: false,


### PR DESCRIPTION
Currently, the drawer does not open the first time the client is loaded
due to the active chat address not being set. This means on desktop you
can never get to the drawer due to the heading bar not being shown. This
commit introduces a temporary fix of showing the drawer on load. A
better fix would be introducing a news page for people to land on.
