### PR TITLE
Fix several type issues with delete message that had occured

### DIFF
--- a/src/relay/client.js
+++ b/src/relay/client.js
@@ -167,13 +167,13 @@ export class RelayClient {
     assert(typeof digest === 'string')
 
     try {
-      const message = this.messageStore.getMessage(digest)
+      const message = await this.messageStore.getMessage(digest)
       assert(message, 'message not found?')
 
       // Send utxos to a change address
       const changeAddresses = Object.keys(this.wallet.changeAddresses)
       const changeAddress = changeAddresses[changeAddresses.length * Math.random() << 0]
-      await this.wallet.forwardUTXOsToAddress({ utxos: message.outpoints, address: changeAddress })
+      await this.wallet.forwardUTXOsToAddress({ utxos: message.newMsg.outpoints, address: changeAddress })
 
       const url = `${this.url}/messages/${this.wallet.myAddressStr}`
       await axios({

--- a/src/wallet/index.js
+++ b/src/wallet/index.js
@@ -286,7 +286,7 @@ export class Wallet {
       const electrumClient = await this.electrumClientPromise
       await electrumClient.request('blockchain.transaction.broadcast', txHex)
       // TODO: we shouldn't be dealing with this here. Leaky abstraction
-      await Promise.forEach(usedIDs.map(id => this.storage.deleteOutpoint(id)))
+      await Promise.all(usedIDs.map(id => this.storage.deleteOutpoint(id)))
     } catch (err) {
       console.error(err)
       // Fix UTXOs if tx broadcast fails


### PR DESCRIPTION
During past refactors, a few issues with delete message and other
parts of the codebase were broken. THis commit fixes the issues around
forwarding deleted UTXOs and an accidental inversion of conditions when
receiving a message with a payload digest instead of a full message.