### PR TITLE
Switch codebase to use parameterized network names for display vs API

### DIFF
--- a/quasar.conf.js
+++ b/quasar.conf.js
@@ -19,6 +19,7 @@ module.exports = configure(function (ctx) {
       'composition-api',
       'i18n',
       'axios',
+      'network-prefix',
       'setup-apis',
       ctx.mode.electron ? 'electron' : 'capacitor'
     ],

--- a/src/boot/network-prefix.ts
+++ b/src/boot/network-prefix.ts
@@ -1,0 +1,43 @@
+import { Networks } from 'bitcore-lib-cash'
+import { boot } from 'quasar/wrappers'
+
+export default boot(() => {
+  // from https://github.com/Bitcoin-ABC/bitcoin-abc/blob/master/src/chainparams.cpp#L212
+  const dnsSeeds = [
+    'seed.bitcoinabc.org',
+    'seeder.jasonbcox.com',
+    'seed.deadalnix.me'
+  ]
+
+  const liveNetwork = {
+    name: 'ecash-livenet',
+    alias: 'ecash-mainnet',
+    prefix: 'ecash',
+    pubkeyhash: 28,
+    privatekey: 0x80,
+    scripthash: 40,
+    xpubkey: 0x0488b21e,
+    xprivkey: 0x0488ade4,
+    networkMagic: 0xe3e1f3e8,
+    port: 8333,
+    dnsSeeds: dnsSeeds
+  }
+
+  // TODO: we need to clean this up.
+  // There shouldn't need to be this additional prefix stuff.
+  const testNetwork = {
+    name: 'ecash-testnet',
+    prefix: 'tecash',
+    pubkeyhash: 0x6f,
+    privatekey: 0xef,
+    scripthash: 0xc4,
+    xpubkey: 0x043587cf,
+    xprivkey: 0x04358394,
+    networkMagic: 0xf4e5f3f4,
+    port: 18333,
+    dnsSeeds: dnsSeeds
+  }
+
+  Networks.add(testNetwork)
+  Networks.add(liveNetwork)
+})

--- a/src/components/dialogs/NewContactDialog.vue
+++ b/src/components/dialogs/NewContactDialog.vue
@@ -100,6 +100,8 @@ import KeyserverHandler from '../../keyserver/handler'
 
 import { Address } from 'bitcore-lib-cash'
 
+import { networkName } from '../../utils/constants'
+
 export default {
   data () {
     return {
@@ -116,7 +118,7 @@ export default {
       this.contact = 'loading'
       try {
         // Validate address
-        const address = Address.fromString(newAddress.trim(), 'testnet').toLegacyAddress().toString() // TODO: Make generic
+        const address = Address.fromString(newAddress.trim(), networkName).toLegacyAddress().toString() // TODO: Make generic
 
         // Pull information from keyserver then relay server
         const ksHandler = new KeyserverHandler()
@@ -136,7 +138,7 @@ export default {
     }),
 
     addContact () {
-      const cashAddress = Address.fromString(this.address, 'testnet').toCashAddress() // TODO: Make generic
+      const cashAddress = Address.fromString(this.address, networkName).toCashAddress() // TODO: Make generic
       this.addContactVuex({ address: cashAddress, contact: this.contact })
     }
   },

--- a/src/components/dialogs/ReceiveBitcoinDialog.vue
+++ b/src/components/dialogs/ReceiveBitcoinDialog.vue
@@ -20,7 +20,7 @@
       <div class="row">
         <qrcode-vue
           style="margin-left: auto; margin-right: auto;"
-          :value="currentAddress"
+          :value="displayAddress"
           :size="300"
           level="H"
         />
@@ -30,7 +30,7 @@
           class="fit"
           filled
           auto-grow
-          v-model="currentAddress"
+          v-model="displayAddress"
           readonly
         >
           <template v-slot:after>
@@ -38,15 +38,15 @@
               dense
               color="primary"
               flat
-              icon="content_copy"
-              @click="copyAddress"
+              icon="swap_vert"
+              @click="toggleLegacy"
             />
             <q-btn
               dense
               color="primary"
               flat
-              icon="refresh"
-              @click="nextAddress"
+              icon="content_copy"
+              @click="copyAddress"
             />
           </template>
         </q-input>
@@ -77,7 +77,6 @@ import QrcodeVue from 'qrcode.vue'
 import SeedPhraseDialog from './SeedPhraseDialog.vue'
 import { mapGetters } from 'vuex'
 import { formatBalance } from '../../utils/formatting'
-import { numAddresses } from '../../utils/constants'
 import { copyToClipboard } from 'quasar'
 
 export default {
@@ -87,9 +86,8 @@ export default {
   },
   data () {
     return {
-      currentAddress: this.$wallet.privKeys[0].toAddress('testnet').toString(), // TODO: Generic over network
-      paymentAddrCounter: 0,
-      seedPhraseOpen: false
+      seedPhraseOpen: false,
+      legacy: false
     }
   },
   computed: {
@@ -98,11 +96,17 @@ export default {
     }),
     formattedBalance () {
       return formatBalance(this.balance)
+    },
+    displayAddress () {
+      return this.legacy ? this.$wallet.myAddressStr : this.$wallet.displayAddress
     }
   },
   methods: {
+    toggleLegacy () {
+      this.legacy = !this.legacy
+    },
     copyAddress () {
-      copyToClipboard(this.currentAddress).then(() => {
+      copyToClipboard(this.displayAddress).then(() => {
         this.$q.notify({
           message: `<div class="text-center">${this.$t('receiveBitcoinDialog.addressCopied')}</div>`,
           html: true,
@@ -112,13 +116,6 @@ export default {
         .catch(() => {
           // fail
         })
-    },
-    nextAddress () {
-      // Increment address
-      // TODO: This should have no idea what number of addresses there are
-      this.paymentAddrCounter = (this.paymentAddrCounter + 1) % numAddresses
-      const privKey = this.$wallet.privKeys[this.paymentAddrCounter]
-      this.currentAddress = privKey.toAddress('testnet').toString()
     }
   }
 }

--- a/src/components/dialogs/RelayConnectDialog.vue
+++ b/src/components/dialogs/RelayConnectDialog.vue
@@ -31,7 +31,7 @@
 export default {
   methods: {
     connect () {
-      this.$relayClient.setUpWebsocket(this.$wallet.myAddress)
+      this.$relayClient.setUpWebsocket(this.$wallet.myAddressStr)
     }
   }
 }

--- a/src/components/dialogs/SendAddressDialog.vue
+++ b/src/components/dialogs/SendAddressDialog.vue
@@ -45,9 +45,10 @@
 </template>
 
 <script>
-import { sentTransactionNotify, errorNotify } from '../../utils/notifications'
-
 import { Address, Transaction, Script } from 'bitcore-lib-cash'
+
+import { sentTransactionNotify, errorNotify } from '../../utils/notifications'
+import { displayNetwork, networkName } from '../../utils/constants'
 
 export default {
   components: {
@@ -63,12 +64,15 @@ export default {
       if (!this.amount) {
         return false
       }
-      try {
-        Address(this.address, 'testnet') // TODO: Make this generic
-        return true
-      } catch {
-        return false
+      for (const networkString of [displayNetwork, networkName]) {
+        try {
+          Address(this.address, networkString) // TODO: Make this generic
+          return true
+        } catch (err) {
+          console.log(`Address not for ${networkString}`)
+        }
       }
+      return false
     }
   },
   methods: {

--- a/src/components/dialogs/TransactionDialog.vue
+++ b/src/components/dialogs/TransactionDialog.vue
@@ -53,6 +53,8 @@
 <script>
 import { Script } from 'bitcore-lib-cash'
 
+import { networkName } from '../../utils/constants'
+
 export default {
   props: {
     title: {
@@ -74,7 +76,7 @@ export default {
     extractAddress (output) {
       const script = new Script(output.script)
       if (script.isPublicKeyHashOut()) {
-        return script.toAddress('testnet') // TODO: Make generic
+        return script.toAddress(networkName) // TODO: Make generic
       }
       return 'Non-p2pkh'
     }

--- a/src/components/panels/ContactCard.vue
+++ b/src/components/panels/ContactCard.vue
@@ -44,7 +44,7 @@
             caption
             lines="1"
           >
-            {{ address }}
+            {{ displayAddress }}
           </q-item-label>
         </q-item-section>
         <q-item-section side>
@@ -65,6 +65,8 @@
 <script>
 import { copyToClipboard } from 'quasar'
 import { addressCopiedNotify } from '../../utils/notifications'
+import { Address, Networks } from 'bitcore-lib-cash'
+import { displayNetwork } from 'src/utils/constants'
 
 export default {
   props: {
@@ -91,13 +93,20 @@ export default {
   },
   methods: {
     copyAddress () {
-      copyToClipboard(this.address)
+      copyToClipboard(this.displayAddress)
         .then(() => {
           addressCopiedNotify()
         })
         .catch(() => {
           // fail
         })
+    }
+  },
+  computed: {
+    displayAddress () {
+      const address = Address(this.address)
+      const displayAddress = Address(address.hashBuffer, Networks.get(displayNetwork)).toCashAddress()
+      return displayAddress
     }
   }
 }

--- a/src/components/panels/ContactPanel.vue
+++ b/src/components/panels/ContactPanel.vue
@@ -26,9 +26,7 @@
 
     <!-- Contact book dialog -->
     <q-dialog v-model="contactBookOpen">
-      <contact-book-dialog
-        :contact-click="function (shareAddr, contact) { return shareContact({ currentAddr: address, shareAddr }) }"
-      />
+      <contact-book-dialog :contact-click="function (shareAddr, contact) { return shareContact({ currentAddr: address, shareAddr }) }" />
     </q-dialog>
 
     <!-- Contact card -->

--- a/src/components/setup/DepositStep.vue
+++ b/src/components/setup/DepositStep.vue
@@ -4,7 +4,7 @@
     <div class="p-mx-sm">
       <qrcode-vue
         class="text-center"
-        :value="identityAddress"
+        :value="displayAddress"
         level="H"
         size="300"
       />
@@ -14,10 +14,17 @@
       class="fit q-px-lg"
       filled
       auto-grow
-      v-model="identityAddress"
+      v-model="displayAddress"
       readonly
     >
       <template v-slot:after>
+        <q-btn
+          dense
+          color="primary"
+          flat
+          icon="swap_vert"
+          @click="toggleLegacy"
+        />
         <q-btn
           dense
           color="primary"
@@ -57,12 +64,16 @@ export default {
     return {
       paymentAddrCounter: 0,
       recomendedBalance,
-      qrSize: 300
+      qrSize: 300,
+      legacy: false
     }
   },
   methods: {
+    toggleLegacy () {
+      this.legacy = !this.legacy
+    },
     copyAddress () {
-      copyToClipboard(this.identityAddress)
+      copyToClipboard(this.displayAddress)
         .then(() => {
           addressCopiedNotify()
         })
@@ -80,8 +91,8 @@ export default {
   },
   computed: {
     ...mapGetters({ balance: 'wallet/balance' }),
-    identityAddress () {
-      return this.$wallet.myAddress.toString()
+    displayAddress () {
+      return this.legacy ? this.$wallet.myAddressStr : this.$wallet.displayAddress
     },
     percentageBalance () {
       const percentage = this.balance / this.recomendedBalance

--- a/src/keyserver/handler.js
+++ b/src/keyserver/handler.js
@@ -2,7 +2,7 @@ import axios from 'axios'
 import { Entry, AddressMetadata } from './keyserver_pb'
 import { AuthWrapper } from '../auth_wrapper/wrapper_pb'
 import pop from '../pop'
-import { trustedKeyservers } from '../utils/constants'
+import { trustedKeyservers, networkName } from '../utils/constants'
 import { crypto } from 'bitcore-lib-cash'
 
 class KeyserverHandler {
@@ -104,7 +104,7 @@ class KeyserverHandler {
   }
 
   async updateKeyMetadata (relayUrl, idPrivKey) {
-    const idAddress = idPrivKey.toAddress('testnet').toLegacyAddress().toString()
+    const idAddress = idPrivKey.toAddress(networkName).toLegacyAddress().toString()
     // Construct metadata
     const authWrapper = KeyserverHandler.constructRelayUrlMetadata(relayUrl, idPrivKey)
 

--- a/src/relay/crypto.js
+++ b/src/relay/crypto.js
@@ -2,6 +2,9 @@ import { PrivateKey, PublicKey, crypto, HDPublicKey, HDPrivateKey } from 'bitcor
 
 import forge from 'node-forge'
 
+// TODO: network clients should not
+import { networkName } from '../utils/constants'
+
 export const constructPayloadHmac = function (sharedKey, payloadDigest) {
   return crypto.Hash.sha256hmac(sharedKey, Buffer.from(payloadDigest))
 }
@@ -33,7 +36,7 @@ export const constructHDStealthPublicKey = function (emphemeralPrivKey, destinat
   return new HDPublicKey({
     publicKey: stealthPublicKey.toBuffer(),
     depth: 0,
-    network: 'testnet',
+    network: networkName,
     childIndex: 0,
     chainCode: digest,
     parentFingerPrint: 0
@@ -57,7 +60,7 @@ export const constructHDStealthPrivateKey = function (emphemeralPubKey, destinat
   return new HDPrivateKey({
     privateKey: stealthPrivateKey.toBuffer(),
     depth: 0,
-    network: 'testnet',
+    network: networkName,
     childIndex: 0,
     chainCode: digest,
     parentFingerPrint: 0
@@ -77,7 +80,7 @@ export const constructStampHDPublicKey = function (payloadDigest, destinationPub
   return new HDPublicKey({
     publicKey: stampPublicKey.toBuffer(),
     depth: 0,
-    network: 'testnet',
+    network: networkName,
     childIndex: 0,
     chainCode: payloadDigest,
     parentFingerPrint: 0
@@ -96,7 +99,7 @@ export const constructStampHDPrivateKey = function (payloadDigest, destinationPr
   return new HDPrivateKey({
     privateKey: stampPrivateKey.toBuffer(),
     depth: 0,
-    network: 'testnet',
+    network: networkName,
     childIndex: 0,
     chainCode: payloadDigest,
     parentFingerPrint: 0
@@ -106,7 +109,7 @@ export const constructStampHDPrivateKey = function (payloadDigest, destinationPr
 export const constructStampAddress = function (outpointDigest, privKey) {
   const digestBn = crypto.BN.fromBuffer(outpointDigest)
   const stampPrivBn = privKey.bn.add(digestBn).mod(crypto.Point.getN())
-  const stampAddress = PrivateKey(stampPrivBn).toAddress('testnet')
+  const stampAddress = PrivateKey(stampPrivBn).toAddress(networkName)
   return stampAddress
 }
 

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -30,6 +30,13 @@ export const electrumServers = [
     scheme: ElectrumTransport.WSS.Scheme
   }
 ]
+
+// The separation here is due the fork. Not all backends support the new network prefixes yet
+// So we are using the legacy prefixes everywhere for API calls, but using
+// the ecash prefix for display
+export const networkName = 'testnet'
+export const displayNetwork = 'ecash-testnet'
+
 export const electrumPingInterval = 10_000
 
 // Wallet constants

--- a/src/wallet/index.js
+++ b/src/wallet/index.js
@@ -37,8 +37,11 @@ const shuffleArray = function (arr) {
 }
 
 export class Wallet {
-  constructor (storage) {
+  constructor (storage, { networkName = 'testnet', displayNetworkName = 'ecash-testnet' } = {}) {
     this.storage = storage
+    this.networkName = networkName
+    this.displayNetworkName = displayNetworkName
+
     this.constructionLock = new Lock()
     // Workaround for the way electrum-cash ensures a subscription isn't handled
     // twice.
@@ -109,7 +112,7 @@ export class Wallet {
         .deriveChild(0)
         .deriveChild(i)
         .privateKey
-      const address = privKey.toAddress('testnet').toLegacyAddress()
+      const address = privKey.toAddress(this.networkName).toLegacyAddress()
       this.setAddress({ address, privKey })
 
       // Index by script hash
@@ -123,7 +126,7 @@ export class Wallet {
         .deriveChild(1)
         .deriveChild(j)
         .privateKey
-      const address = privKey.toAddress('testnet').toLegacyAddress()
+      const address = privKey.toAddress(this.networkName).toLegacyAddress()
       this.setChangeAddress({ address, privKey })
 
       // Index by script hash
@@ -593,13 +596,20 @@ export class Wallet {
   get myAddress () {
     // TODO: This should be in the relay client, not the wallet...
     // TODO: Not just testnet
-    return this.identityPrivKey.toAddress('testnet')
+    return this.identityPrivKey.toAddress(this.networkName)
   }
 
   get myAddressStr () {
     // TODO: This should be in the relay client, not the wallet...
     // TODO: Not just testnet
-    return this.identityPrivKey.toAddress('testnet')
+    return this.identityPrivKey.toAddress(this.networkName)
+      .toCashAddress()
+  }
+
+  get displayAddress () {
+    // TODO: This should be in the relay client, not the wallet...
+    // TODO: Not just testnet
+    return this.identityPrivKey.toAddress(this.displayNetworkName)
       .toCashAddress()
   }
 


### PR DESCRIPTION
Currently, Bitcoin ABC is still using the `bitcoincash` address prefix.
However, this is not a long term situation. Additionally, our codebase
hardcodes the network name in many different places. This commit splits
the display of addresses, and the use of the addresses in the API
backend -- and uses one constant everywhere so it'll be easy to swap
out.
