### PR TITLE
Ensure signups for *BRAND NEW* accounts don't fail

### DIFF
--- a/src/i18n/en-us/index.ts
+++ b/src/i18n/en-us/index.ts
@@ -23,7 +23,7 @@ export default {
     seedWarning: 'Do not forget your character\'s secret name, you will never be able to remember them again.',
     searchingRelay: 'Searching for existing relay data...',
     networkErrorRelayDied: 'Network Error: Relay server connection died. ',
-    networkErrorRelayUnexpected: 'Network error: Relay disconnnected unexpectedly.',
+    networkErrorRelayUnexpected: 'Network error: Relay errored unexpectedly.',
     requestingPayment: 'Requesting Payment...',
     sendingPayment: 'Sending Payment...',
     uploadingMetaData: 'Uploading Metadata...',

--- a/src/keyserver/handler.js
+++ b/src/keyserver/handler.js
@@ -120,10 +120,11 @@ class KeyserverHandler {
     const { paymentDetails } = await KeyserverHandler.paymentRequest(serverUrl, idAddress, truncatedAuthWrapper)
 
     // Construct payment
-    const { paymentUrl, payment } = await pop.constructPaymentTransaction(this.wallet, paymentDetails)
+    const { paymentUrl, payment, usedIDs } = await pop.constructPaymentTransaction(this.wallet, paymentDetails)
 
     const paymentUrlFull = new URL(paymentUrl, serverUrl)
     const { token } = await pop.sendPayment(paymentUrlFull.href, payment)
+    await Promise.all(usedIDs.map(id => this.wallet.storage.deleteOutpoint(id)))
 
     await KeyserverHandler.putMetadata(idAddress, serverUrl, authWrapper, token)
   }


### PR DESCRIPTION
When a person signs up, they need to make two payments immediately.
One for the keyserver, and one for the relay server. However, if they
only have one UTXO, this won't be possible until the change of the first
transaction settles. This commit updates the error handling around the
second payment to retry until there are funds in the wallet due to
the subscriptions from the first transaction being hit.
